### PR TITLE
feat(web): iOS-style motion system — nav pills, page transitions, nat…

### DIFF
--- a/apps/skillnet-web/src/components/layout/AdminLayout.tsx
+++ b/apps/skillnet-web/src/components/layout/AdminLayout.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence, motion } from 'framer-motion'
 import { AdminSidebar } from './AdminSidebar'
 import { Header } from './Header'
 import { SidebarProvider, useSidebar } from '../../contexts/SidebarContext'
+import { pageTransition } from '../../lib/motion'
 
 function AdminLayoutInner() {
   const location = useLocation()
@@ -23,10 +24,7 @@ function AdminLayoutInner() {
           <AnimatePresence mode="wait">
             <motion.div
               key={location.pathname}
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.2 }}
+              {...pageTransition}
               className="p-4 md:p-6"
             >
               <Outlet />

--- a/apps/skillnet-web/src/components/layout/AdminSidebar.tsx
+++ b/apps/skillnet-web/src/components/layout/AdminSidebar.tsx
@@ -1,8 +1,8 @@
-import { NavLink, useLocation } from 'react-router-dom'
+import { NavLink } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useSidebar } from '../../contexts/SidebarContext'
-import type { RefObject } from 'react'
-import { useRef, useLayoutEffect, useState } from 'react'
+import { NavPill } from './NavPill'
+import { backdrop, sidebarSlide } from '../../lib/motion'
 
 interface NavItem {
   label: string
@@ -87,57 +87,8 @@ function SpiderIcon() {
   )
 }
 
-function ActivePill({
-  activeIndex,
-  collapsed,
-  navRef,
-  itemRefs,
-}: {
-  activeIndex: number
-  collapsed: boolean
-  navRef: RefObject<HTMLElement | null>
-  itemRefs: RefObject<(HTMLAnchorElement | null)[]>
-}) {
-  const [pos, setPos] = useState<{ top: number; height: number } | null>(null)
-
-  useLayoutEffect(() => {
-    const nav = navRef.current
-    const item = itemRefs.current[activeIndex]
-    if (!nav || !item) return
-
-    const navRect = nav.getBoundingClientRect()
-    const itemRect = item.getBoundingClientRect()
-
-    setPos({
-      top: itemRect.top - navRect.top,
-      height: itemRect.height,
-    })
-  }, [activeIndex, collapsed, navRef, itemRefs])
-
-  if (pos === null) return null
-
-  const radiusClass = collapsed ? 'rounded-lg' : 'rounded-l-xl'
-  const leftClass = collapsed ? 'left-2 right-2' : 'left-10 right-4'
-
-  return (
-    <motion.div
-      className={`absolute bg-white ${leftClass} ${radiusClass} pointer-events-none`}
-      animate={{ top: pos.top, height: pos.height }}
-      initial={false}
-      transition={{ type: 'spring', stiffness: 500, damping: 35, mass: 0.5 }}
-    />
-  )
-}
-
-function AdminSidebarContent({ collapsed }: { collapsed: boolean }) {
+function AdminSidebarContent({ collapsed, pillId }: { collapsed: boolean; pillId: string }) {
   const { closeMobile } = useSidebar()
-  const { pathname } = useLocation()
-  const navRef = useRef<HTMLElement>(null)
-  const itemRefs = useRef<(HTMLAnchorElement | null)[]>([])
-
-  const activeIndex = navItems.findIndex((item) =>
-    item.end ? pathname === item.to : pathname === item.to || pathname.startsWith(`${item.to}/`),
-  )
 
   return (
     <>
@@ -174,19 +125,15 @@ function AdminSidebarContent({ collapsed }: { collapsed: boolean }) {
       </div>
 
       {/* Nav */}
-      <nav ref={navRef} className="flex-1 flex flex-col gap-1 relative">
-        <ActivePill activeIndex={activeIndex} collapsed={collapsed} navRef={navRef} itemRefs={itemRefs} />
-        {navItems.map((item, index) => (
+      <nav className="flex-1 flex flex-col gap-1">
+        {navItems.map((item) => (
           <NavLink
             key={item.to}
             to={item.to}
             end={item.end}
-            ref={(el) => {
-              itemRefs.current[index] = el
-            }}
             onClick={closeMobile}
             className={({ isActive }) =>
-              `relative z-10 flex items-center h-10 text-sm font-medium overflow-hidden transition-colors duration-200 ${
+              `relative flex items-center h-10 text-sm font-medium overflow-hidden transition-colors duration-200 ${
                 collapsed
                   ? 'mx-2 px-0 justify-center rounded-lg'
                   : 'ml-10 pl-4 pr-4 rounded-l-xl'
@@ -198,14 +145,19 @@ function AdminSidebarContent({ collapsed }: { collapsed: boolean }) {
             }
             title={collapsed ? item.label : undefined}
           >
-            <span className="shrink-0">{item.icon}</span>
-            <span
-              className={`transition-all duration-300 ease-in-out overflow-hidden whitespace-nowrap ${
-                collapsed ? 'max-w-0 opacity-0 ml-0' : 'max-w-[160px] opacity-100 ml-3'
-              }`}
-            >
-              {item.label}
-            </span>
+            {({ isActive }) => (
+              <>
+                {isActive && <NavPill layoutId={pillId} collapsed={collapsed} />}
+                <span className="relative z-10 shrink-0">{item.icon}</span>
+                <span
+                  className={`relative z-10 transition-all duration-300 ease-in-out overflow-hidden whitespace-nowrap ${
+                    collapsed ? 'max-w-0 opacity-0 ml-0' : 'max-w-[160px] opacity-100 ml-3'
+                  }`}
+                >
+                  {item.label}
+                </span>
+              </>
+            )}
           </NavLink>
         ))}
       </nav>
@@ -241,31 +193,25 @@ export function AdminSidebar() {
           collapsed ? 'w-16' : 'w-[248px]'
         }`}
       >
-        <AdminSidebarContent collapsed={collapsed} />
+        <AdminSidebarContent collapsed={collapsed} pillId="admin-nav-pill" />
       </aside>
 
       {/* Mobile overlay */}
       <AnimatePresence>
         {mobileOpen && (
           <>
-            {/* Backdrop */}
+            {/* Backdrop — frosted glass, not heavy black */}
             <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.2 }}
-              className="fixed inset-0 bg-black/50 z-30 md:hidden"
+              {...backdrop}
+              className="fixed inset-0 bg-black/10 backdrop-blur-sm z-30 md:hidden"
               onClick={closeMobile}
             />
-            {/* Slide-in sidebar */}
+            {/* Slide-in sidebar — spring physics */}
             <motion.aside
-              initial={{ x: '-100%' }}
-              animate={{ x: 0 }}
-              exit={{ x: '-100%' }}
-              transition={{ duration: 0.3, ease: 'easeOut' }}
+              {...sidebarSlide}
               className="fixed left-0 top-0 bottom-0 w-[248px] frame-surface flex flex-col z-40 md:hidden"
             >
-              <AdminSidebarContent collapsed={false} />
+              <AdminSidebarContent collapsed={false} pillId="admin-nav-pill-mobile" />
             </motion.aside>
           </>
         )}

--- a/apps/skillnet-web/src/components/layout/AppLayout.tsx
+++ b/apps/skillnet-web/src/components/layout/AppLayout.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence, motion } from 'framer-motion'
 import { Sidebar } from './Sidebar'
 import { Header } from './Header'
 import { SidebarProvider, useSidebar } from '../../contexts/SidebarContext'
+import { pageTransition } from '../../lib/motion'
 
 function AppLayoutInner() {
   const location = useLocation()
@@ -23,10 +24,7 @@ function AppLayoutInner() {
           <AnimatePresence mode="wait">
             <motion.div
               key={location.pathname}
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.2 }}
+              {...pageTransition}
               className="p-4 md:p-6"
             >
               <Outlet />

--- a/apps/skillnet-web/src/components/layout/Header.tsx
+++ b/apps/skillnet-web/src/components/layout/Header.tsx
@@ -1,9 +1,13 @@
 import { useEffect, useRef, useState } from 'react'
+import { motion } from 'framer-motion'
 import { useMe, useLogout } from '../../api/auth'
+import { useSidebar } from '../../contexts/SidebarContext'
+import { transition } from '../../lib/motion'
 
 export function Header() {
   const { data: user } = useMe()
   const logout = useLogout()
+  const { setMobileOpen } = useSidebar()
   const [open, setOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
 
@@ -19,7 +23,23 @@ export function Header() {
   }, [open])
 
   return (
-    <header className="fixed top-0 right-0 h-[50px] frame-surface flex items-center justify-end px-4 md:px-6 z-10">
+    <header className="fixed top-0 left-0 right-0 md:left-auto h-[50px] frame-surface flex items-center justify-between md:justify-end px-4 md:px-6 z-10">
+      {/* Mobile menu trigger — opens the sidebar overlay */}
+      <motion.button
+        type="button"
+        onClick={() => setMobileOpen(true)}
+        aria-label="Abrir menu"
+        className="md:hidden w-9 h-9 -ml-1 flex items-center justify-center rounded-lg text-white/90 hover:text-white cursor-pointer"
+        whileTap={{ scale: 0.9 }}
+        transition={transition.micro}
+      >
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <line x1="3" y1="6" x2="21" y2="6" />
+          <line x1="3" y1="12" x2="21" y2="12" />
+          <line x1="3" y1="18" x2="21" y2="18" />
+        </svg>
+      </motion.button>
+
       <div className="relative" ref={menuRef}>
         <button
           type="button"

--- a/apps/skillnet-web/src/components/layout/NavPill.tsx
+++ b/apps/skillnet-web/src/components/layout/NavPill.tsx
@@ -1,0 +1,22 @@
+import { motion } from 'framer-motion'
+import { spring } from '../../lib/motion'
+
+/**
+ * White active-nav pill. Rendered as an absolutely-positioned background inside
+ * the *active* NavLink; framer-motion's shared-layout (`layoutId`) slides it
+ * between items with spring physics as the active route changes — no manual
+ * measurement, so it's robust to StrictMode ref detach/reattach.
+ *
+ * `inset-0` makes it inherit the NavLink's own box, so it fuses to the right
+ * edge of the sidebar (expanded) and becomes an inset chip (collapsed) for free.
+ */
+export function NavPill({ layoutId, collapsed }: { layoutId: string; collapsed: boolean }) {
+  return (
+    <motion.span
+      layoutId={layoutId}
+      aria-hidden
+      className={`absolute inset-0 bg-white pointer-events-none ${collapsed ? 'rounded-lg' : 'rounded-l-xl'}`}
+      transition={spring.stiff}
+    />
+  )
+}

--- a/apps/skillnet-web/src/components/layout/Sidebar.tsx
+++ b/apps/skillnet-web/src/components/layout/Sidebar.tsx
@@ -1,17 +1,21 @@
 import { NavLink } from 'react-router-dom'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useSidebar } from '../../contexts/SidebarContext'
+import { NavPill } from './NavPill'
+import { backdrop, sidebarSlide } from '../../lib/motion'
 
 interface NavItem {
   label: string
   to: string
   icon: React.ReactNode
+  end?: boolean
 }
 
 const navItems: NavItem[] = [
   {
     label: 'Inicio',
     to: '/empleado',
+    end: true,
     icon: (
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
         <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
@@ -57,7 +61,7 @@ function SpiderIcon() {
   )
 }
 
-function SidebarContent({ collapsed }: { collapsed: boolean }) {
+function SidebarContent({ collapsed, pillId }: { collapsed: boolean; pillId: string }) {
   const { closeMobile } = useSidebar()
 
   return (
@@ -85,29 +89,34 @@ function SidebarContent({ collapsed }: { collapsed: boolean }) {
           <NavLink
             key={item.to}
             to={item.to}
-            end={item.to === '/empleado'}
+            end={item.end}
             onClick={closeMobile}
             className={({ isActive }) =>
-              `flex items-center h-10 text-sm font-medium overflow-hidden transition-colors duration-200 ${
+              `relative flex items-center h-10 text-sm font-medium overflow-hidden transition-colors duration-200 ${
                 collapsed
                   ? 'mx-2 px-0 justify-center rounded-lg'
                   : 'ml-10 pl-4 pr-4 rounded-l-xl'
               } ${
                 isActive
-                  ? 'bg-white text-primary'
+                  ? 'text-primary'
                   : 'text-white/80 hover:text-white'
               }`
             }
             title={collapsed ? item.label : undefined}
           >
-            <span className="shrink-0">{item.icon}</span>
-            <span
-              className={`transition-all duration-300 ease-in-out overflow-hidden whitespace-nowrap ${
-                collapsed ? 'max-w-0 opacity-0 ml-0' : 'max-w-[160px] opacity-100 ml-3'
-              }`}
-            >
-              {item.label}
-            </span>
+            {({ isActive }) => (
+              <>
+                {isActive && <NavPill layoutId={pillId} collapsed={collapsed} />}
+                <span className="relative z-10 shrink-0">{item.icon}</span>
+                <span
+                  className={`relative z-10 transition-all duration-300 ease-in-out overflow-hidden whitespace-nowrap ${
+                    collapsed ? 'max-w-0 opacity-0 ml-0' : 'max-w-[160px] opacity-100 ml-3'
+                  }`}
+                >
+                  {item.label}
+                </span>
+              </>
+            )}
           </NavLink>
         ))}
       </nav>
@@ -143,31 +152,25 @@ export function Sidebar() {
           collapsed ? 'w-16' : 'w-[248px]'
         }`}
       >
-        <SidebarContent collapsed={collapsed} />
+        <SidebarContent collapsed={collapsed} pillId="employee-nav-pill" />
       </aside>
 
       {/* Mobile overlay */}
       <AnimatePresence>
         {mobileOpen && (
           <>
-            {/* Backdrop */}
+            {/* Backdrop — frosted glass, not heavy black */}
             <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.2 }}
-              className="fixed inset-0 bg-black/50 z-30 md:hidden"
+              {...backdrop}
+              className="fixed inset-0 bg-black/10 backdrop-blur-sm z-30 md:hidden"
               onClick={closeMobile}
             />
-            {/* Slide-in sidebar */}
+            {/* Slide-in sidebar — spring physics */}
             <motion.aside
-              initial={{ x: '-100%' }}
-              animate={{ x: 0 }}
-              exit={{ x: '-100%' }}
-              transition={{ duration: 0.3, ease: 'easeOut' }}
+              {...sidebarSlide}
               className="fixed left-0 top-0 bottom-0 w-[248px] frame-surface flex flex-col z-40 md:hidden"
             >
-              <SidebarContent collapsed={false} />
+              <SidebarContent collapsed={false} pillId="employee-nav-pill-mobile" />
             </motion.aside>
           </>
         )}

--- a/apps/skillnet-web/src/components/ui/Button.tsx
+++ b/apps/skillnet-web/src/components/ui/Button.tsx
@@ -1,9 +1,10 @@
-import type { ButtonHTMLAttributes } from 'react'
+import { motion, type HTMLMotionProps } from 'framer-motion'
+import { transition } from '../../lib/motion'
 
 type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'accent' | 'danger'
 type ButtonSize = 'sm' | 'md' | 'lg'
 
-export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps extends HTMLMotionProps<'button'> {
   variant?: ButtonVariant
   size?: ButtonSize
 }
@@ -36,7 +37,7 @@ export function Button({
   ...props
 }: ButtonProps) {
   return (
-    <button
+    <motion.button
       className={`
         inline-flex items-center justify-center font-medium rounded-lg max-w-full
         transition-colors duration-150 cursor-pointer
@@ -47,9 +48,12 @@ export function Button({
         ${className}
       `}
       disabled={disabled}
+      whileHover={disabled ? undefined : { scale: 1.03 }}
+      whileTap={disabled ? undefined : { scale: 0.97 }}
+      transition={transition.micro}
       {...props}
     >
       {children}
-    </button>
+    </motion.button>
   )
 }

--- a/apps/skillnet-web/src/components/ui/Card.tsx
+++ b/apps/skillnet-web/src/components/ui/Card.tsx
@@ -1,8 +1,9 @@
-import type { HTMLAttributes } from 'react'
+import { motion, type HTMLMotionProps } from 'framer-motion'
+import { spring, duration, ease } from '../../lib/motion'
 
 type CardVariant = 'default' | 'interactive'
 
-export interface CardProps extends HTMLAttributes<HTMLDivElement> {
+export interface CardProps extends HTMLMotionProps<'div'> {
   variant?: CardVariant
 }
 
@@ -19,13 +20,20 @@ export function Card({
   children,
   ...props
 }: CardProps) {
+  const interactive = variant === 'interactive'
+
   return (
-    <div
+    <motion.div
       className={`${variantClasses[variant]} ${className}`}
+      whileHover={interactive ? { scale: 1.02, boxShadow: '0 8px 32px -8px rgba(0,0,0,0.12)' } : undefined}
+      transition={{
+        scale: spring.default,
+        boxShadow: { duration: duration.normal, ease: ease.base },
+      }}
       {...props}
     >
       {children}
-    </div>
+    </motion.div>
   )
 }
 

--- a/apps/skillnet-web/src/components/ui/Modal.tsx
+++ b/apps/skillnet-web/src/components/ui/Modal.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { motion, useAnimationControls } from 'framer-motion'
+import { duration, ease } from '../../lib/motion'
+
+type ModalSize = 'sm' | 'md' | 'lg'
+
+const sizeClasses: Record<ModalSize, string> = {
+  sm: 'max-w-md',
+  md: 'max-w-lg',
+  lg: 'max-w-2xl',
+}
+
+export interface ModalProps {
+  open: boolean
+  onClose: () => void
+  children: React.ReactNode
+  size?: ModalSize
+  /** Rect of the control that opened the modal — the panel grows from / shrinks to it (FLIP). */
+  origin?: DOMRect | null
+  /** Hide the top-right close button (e.g. when the content provides its own). */
+  hideClose?: boolean
+}
+
+function CloseIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  )
+}
+
+/** Delta transform that maps the panel's current box onto the origin control's box. */
+function flipToOrigin(panel: DOMRect, origin: DOMRect | null | undefined) {
+  const o = origin && origin.width ? origin : new DOMRect(panel.left + panel.width / 2 - 24, panel.top + panel.height / 2 - 24, 48, 48)
+  const scale = Math.min(Math.max(o.width / panel.width, 0.08), 1)
+  return {
+    x: o.left + o.width / 2 - (panel.left + panel.width / 2),
+    y: o.top + o.height / 2 - (panel.top + panel.height / 2),
+    scale,
+  }
+}
+
+/**
+ * Clean, native-feeling modal — modeled on stepbro.site's `<window>`:
+ * a borderless surface with a large radius and deep soft shadow that **grows
+ * from the trigger control** (FLIP zoom-from-origin) over the signature ease,
+ * while the content **blurs in** once the box has settled. Portaled to
+ * `document.body` so it escapes the page-transition transform.
+ */
+export function Modal({ open, onClose, children, size = 'md', origin, hideClose = false }: ModalProps) {
+  const [mounted, setMounted] = useState(open)
+  const panelRef = useRef<HTMLDivElement>(null)
+  const panel = useAnimationControls()
+  const scrim = useAnimationControls()
+  const closingRef = useRef(false)
+
+  // Mount as soon as it opens; unmount only after the close animation finishes.
+  useEffect(() => {
+    if (open) {
+      closingRef.current = false
+      setMounted(true)
+    }
+  }, [open])
+
+  // Enter — grow from the origin control.
+  useLayoutEffect(() => {
+    if (!open || !mounted) return
+    const el = panelRef.current
+    if (!el) return
+    const from = flipToOrigin(el.getBoundingClientRect(), origin)
+    panel.set({ x: from.x, y: from.y, scale: from.scale, opacity: 0 })
+    panel.start({ x: 0, y: 0, scale: 1, opacity: 1, transition: { duration: duration.slow, ease: ease.base } })
+    scrim.set({ opacity: 0 })
+    scrim.start({ opacity: 1, transition: { duration: duration.fast } })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, mounted])
+
+  // Exit — shrink back toward the origin control, then unmount.
+  useEffect(() => {
+    if (open || !mounted || closingRef.current) return
+    closingRef.current = true
+    const el = panelRef.current
+    if (!el) {
+      setMounted(false)
+      return
+    }
+    const to = flipToOrigin(el.getBoundingClientRect(), origin)
+    scrim.start({ opacity: 0, transition: { duration: duration.normal } })
+    panel
+      .start({ x: to.x, y: to.y, scale: to.scale, opacity: 0, transition: { duration: duration.normal, ease: ease.base } })
+      .then(() => setMounted(false))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, mounted])
+
+  // Escape to close + scroll lock while mounted.
+  useEffect(() => {
+    if (!mounted) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.body.style.overflow = prevOverflow
+    }
+  }, [mounted, onClose])
+
+  if (!mounted) return null
+
+  return createPortal(
+    <div className="fixed inset-0 z-[100] flex items-start sm:items-center justify-center p-4 sm:p-6">
+      <motion.div
+        className="absolute inset-0 bg-slate-900/25 backdrop-blur-md"
+        initial={false}
+        animate={scrim}
+        onClick={onClose}
+      />
+      <motion.div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        initial={false}
+        animate={panel}
+        style={{ borderRadius: 28, transformOrigin: 'center', willChange: 'transform' }}
+        className={`relative z-10 w-full ${sizeClasses[size]} max-h-[calc(100vh-2rem)] overflow-y-auto bg-bg shadow-[0_32px_80px_-24px_rgba(15,23,42,0.45)] p-6 sm:p-7`}
+      >
+        {!hideClose && (
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Cerrar"
+            className="absolute top-4 right-4 z-10 w-8 h-8 flex items-center justify-center rounded-full text-text-muted hover:text-text hover:bg-bg-muted transition-colors cursor-pointer"
+          >
+            <CloseIcon />
+          </button>
+        )}
+        {/* Content blurs in once the box has grown. */}
+        <motion.div
+          initial={{ opacity: 0, filter: 'blur(6px)' }}
+          animate={{ opacity: 1, filter: 'blur(0px)' }}
+          transition={{ delay: 0.18, duration: duration.normal, ease: ease.base }}
+        >
+          {children}
+        </motion.div>
+      </motion.div>
+    </div>,
+    document.body,
+  )
+}

--- a/apps/skillnet-web/src/components/ui/index.ts
+++ b/apps/skillnet-web/src/components/ui/index.ts
@@ -22,6 +22,9 @@ export type { InputProps } from './Input'
 export { MetricCard } from './MetricCard'
 export type { MetricCardProps } from './MetricCard'
 
+export { Modal } from './Modal'
+export type { ModalProps } from './Modal'
+
 export { ProgressBar } from './ProgressBar'
 export type { ProgressBarProps } from './ProgressBar'
 

--- a/apps/skillnet-web/src/index.css
+++ b/apps/skillnet-web/src/index.css
@@ -44,10 +44,43 @@
 
   /* Font */
   --font-sans: 'Inter', -apple-system, system-ui, sans-serif;
+
+  /* Motion — easing curves (mirror src/lib/motion.ts for CSS-only transitions) */
+  --ease-base: cubic-bezier(0.38, 0.49, 0, 1);
+  --ease-bounce: cubic-bezier(0.38, 0.49, 0, 1.16);
+  --ease-bounce-mid: cubic-bezier(0.38, 0.49, 0, 1.5);
+  --ease-bounce-hard: cubic-bezier(0.38, 0.49, 0, 2);
+  --ease-snap-in: cubic-bezier(0.1, 0.8, 0, 1);
+  --ease-snap-out: cubic-bezier(0.1, 0, 0.7, 1);
+  --ease-morph: cubic-bezier(0.56, 0.27, 0, 1);
 }
 
 *, *::before, *::after {
   min-width: 0;
+}
+
+/* GPU acceleration — pre-promote interactive elements that scale/translate */
+a, button {
+  will-change: transform;
+}
+
+/* Input focus ring — signature-curve box-shadow transition (CSS-only) */
+input:focus {
+  transition: box-shadow 0.3s var(--ease-base);
+}
+
+/* Frosted glass surface — iOS-style translucent panel */
+.glass-panel {
+  background: rgba(255, 255, 255, 0.72);
+  backdrop-filter: blur(24px) saturate(1.2);
+  -webkit-backdrop-filter: blur(24px) saturate(1.2);
+  transform: translateZ(0);
+}
+
+@media (prefers-color-scheme: dark) {
+  .glass-panel {
+    background: rgba(0, 0, 0, 0.8);
+  }
 }
 
 body {

--- a/apps/skillnet-web/src/pages/admin/Content.tsx
+++ b/apps/skillnet-web/src/pages/admin/Content.tsx
@@ -1,7 +1,9 @@
 import { useNavigate } from 'react-router-dom'
+import { motion } from 'framer-motion'
 import { Card, Badge, Button, EmptyState, SkeletonCard } from '../../components/ui'
 import { useCourses } from '../../api/courses'
 import { ApiError } from '../../api/client'
+import { staggerContainer, staggerItem } from '../../lib/motion'
 import type { CourseStatus } from '../../types'
 
 const statusConfig: Record<string, { label: string; variant: 'accent' | 'warning' | 'primary' }> = {
@@ -94,10 +96,11 @@ export function Content() {
             />
           </Card>
         ) : (
-          courses.map((course) => {
+          <motion.div className="space-y-2" initial="hidden" animate="visible" variants={staggerContainer}>
+          {courses.map((course) => {
             const status = statusOf(course.status)
             return (
-              <Card key={course.id}>
+              <Card key={course.id} variants={staggerItem}>
                 <div className="flex items-center gap-4 min-w-0">
                   <div className="text-text-muted shrink-0">
                     <BookIcon />
@@ -118,7 +121,8 @@ export function Content() {
                 </div>
               </Card>
             )
-          })
+          })}
+          </motion.div>
         )}
       </div>
     </div>

--- a/apps/skillnet-web/src/pages/admin/CreateCourse.tsx
+++ b/apps/skillnet-web/src/pages/admin/CreateCourse.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
+import { ease, duration } from '../../lib/motion'
 import { Card, CardTitle, Button, Input, Badge, EmptyState, FileUploadZone, ProgressBar } from '../../components/ui'
 import { GenerationProgress } from '../../components/generation/GenerationProgress'
 import { useUploadDocument, useProcessDocument } from '../../api/documents'
@@ -84,8 +85,14 @@ function StepSource({ selected, onSelect }: { selected: SourceType; onSelect: (s
         {sources.map((s) => (
           <Card
             key={s.key}
-            variant={s.disabled ? 'default' : 'interactive'}
-            className={`${selected === s.key ? 'border-primary bg-primary-subtle' : ''} ${s.disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+            variant="default"
+            className={`transition-colors ${
+              s.disabled
+                ? 'opacity-50 cursor-not-allowed'
+                : selected === s.key
+                  ? 'border-primary bg-primary-subtle cursor-pointer'
+                  : 'cursor-pointer hover:border-primary'
+            }`}
             onClick={() => !s.disabled && onSelect(s.key)}
           >
             <div className="text-text-secondary mb-3">{s.icon}</div>
@@ -243,10 +250,22 @@ function StepAssign({ selected, onToggle, deadline, onDeadline }: {
   )
 }
 
+// Wizard step slide — blur + signature curve, with iOS-style asymmetry:
+// entering a step is deliberate (slow, snapIn), leaving is quick (fast, snapOut).
 const slideVariants = {
-  enter: (dir: Direction) => ({ x: dir > 0 ? 200 : -200, opacity: 0 }),
-  center: { x: 0, opacity: 1 },
-  exit: (dir: Direction) => ({ x: dir > 0 ? -200 : 200, opacity: 0 }),
+  enter: (dir: Direction) => ({ x: dir > 0 ? 200 : -200, opacity: 0, filter: 'blur(6px)' }),
+  center: {
+    x: 0,
+    opacity: 1,
+    filter: 'blur(0px)',
+    transition: { duration: 0.4, ease: ease.snapIn },
+  },
+  exit: (dir: Direction) => ({
+    x: dir > 0 ? -200 : 200,
+    opacity: 0,
+    filter: 'blur(6px)',
+    transition: { duration: duration.fast, ease: ease.snapOut },
+  }),
 }
 
 export function CreateCourse() {
@@ -414,7 +433,7 @@ export function CreateCourse() {
 
       <div className="mt-6 overflow-hidden">
         <AnimatePresence mode="wait" custom={direction}>
-          <motion.div key={step} custom={direction} variants={slideVariants} initial="enter" animate="center" exit="exit" transition={{ duration: 0.2, ease: 'easeOut' }}>
+          <motion.div key={step} custom={direction} variants={slideVariants} initial="enter" animate="center" exit="exit">
             {renderStep()}
           </motion.div>
         </AnimatePresence>

--- a/apps/skillnet-web/src/pages/admin/Employees.tsx
+++ b/apps/skillnet-web/src/pages/admin/Employees.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react'
-import { Card, CardTitle, Badge, Button, Input, EmptyState, SkeletonRow } from '../../components/ui'
+import { motion } from 'framer-motion'
+import { Card, CardTitle, Badge, Button, Input, EmptyState, SkeletonRow, Modal } from '../../components/ui'
 import { useUsers, useCreateUser } from '../../api/users'
 import { useCourses } from '../../api/courses'
 import { useEnrollments, useAssignCourse } from '../../api/enrollments'
 import { ApiError } from '../../api/client'
+import { staggerContainer, staggerItem } from '../../lib/motion'
 import type { User } from '../../types'
 
 function SearchIcon() {
@@ -36,7 +38,7 @@ function CreateEmployeeForm({ onDone }: { onDone: () => void }) {
   if (created) {
     const shownPassword = created.temporary_password ?? password
     return (
-      <Card className="mt-4">
+      <div>
         <CardTitle className="mb-2">Empleado creado</CardTitle>
         <p className="text-sm text-text-secondary mb-3">
           Comparte estas credenciales con {created.full_name}. La contraseña no se volvera a mostrar.
@@ -48,12 +50,12 @@ function CreateEmployeeForm({ onDone }: { onDone: () => void }) {
         <div className="flex gap-2 mt-4">
           <Button size="sm" onClick={onDone}>Listo</Button>
         </div>
-      </Card>
+      </div>
     )
   }
 
   return (
-    <Card className="mt-4">
+    <div>
       <CardTitle className="mb-3">Nuevo empleado</CardTitle>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <Input label="Nombre completo" value={fullName} onChange={(e) => setFullName(e.target.value)} placeholder="Ej: Laura Martinez" />
@@ -80,7 +82,7 @@ function CreateEmployeeForm({ onDone }: { onDone: () => void }) {
         </Button>
         <Button size="sm" variant="ghost" onClick={onDone}>Cancelar</Button>
       </div>
-    </Card>
+    </div>
   )
 }
 
@@ -133,46 +135,41 @@ function AssignCourseForm({ user }: { user: User }) {
   )
 }
 
-function EmployeeDetail({ employee, onBack }: { employee: User; onBack: () => void }) {
+function EmployeeDetail({ employee }: { employee: User }) {
   const { data: enrollmentData, isLoading } = useEnrollments({ user_id: employee.id })
   const enrollments = enrollmentData?.items ?? []
 
   return (
     <div>
-      <button type="button" onClick={onBack} className="text-sm text-primary hover:underline cursor-pointer mb-4">
-        Volver a la lista
-      </button>
-      <Card>
-        <div className="min-w-0">
-          <h3 className="text-lg font-semibold text-text truncate">{employee.full_name}</h3>
-          <p className="text-sm text-text-secondary truncate">{employee.email}</p>
-        </div>
+      <div className="min-w-0 pr-8">
+        <h3 className="text-lg font-semibold text-text truncate">{employee.full_name}</h3>
+        <p className="text-sm text-text-secondary truncate">{employee.email}</p>
+      </div>
 
-        <div className="mt-5">
-          <CardTitle>Cursos asignados</CardTitle>
-          <div className="mt-3">
-            {isLoading ? (
-              <SkeletonRow />
-            ) : enrollments.length === 0 ? (
-              <p className="text-sm text-text-muted">Sin cursos asignados.</p>
-            ) : (
-              <div className="space-y-0">
-                {enrollments.map((e) => (
-                  <div key={e.id} className="flex items-center justify-between py-2.5 border-b border-border last:border-b-0">
-                    <span className="text-sm text-text truncate min-w-0">{e.course_title}</span>
-                    <span className="text-xs text-text-muted shrink-0 ml-4">{e.progress ?? 0}%</span>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
+      <div className="mt-6">
+        <CardTitle>Cursos asignados</CardTitle>
+        <div className="mt-3">
+          {isLoading ? (
+            <SkeletonRow />
+          ) : enrollments.length === 0 ? (
+            <p className="text-sm text-text-muted">Sin cursos asignados.</p>
+          ) : (
+            <div className="space-y-0">
+              {enrollments.map((e) => (
+                <div key={e.id} className="flex items-center justify-between py-2.5 border-b border-border last:border-b-0">
+                  <span className="text-sm text-text truncate min-w-0">{e.course_title}</span>
+                  <span className="text-xs text-text-muted shrink-0 ml-4">{e.progress ?? 0}%</span>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
+      </div>
 
-        <div className="mt-5 border-t border-border pt-5">
-          <CardTitle>Asignar nuevo curso</CardTitle>
-          <AssignCourseForm user={employee} />
-        </div>
-      </Card>
+      <div className="mt-5 border-t border-border pt-5">
+        <CardTitle>Asignar nuevo curso</CardTitle>
+        <AssignCourseForm user={employee} />
+      </div>
     </div>
   )
 }
@@ -181,13 +178,16 @@ export function Employees() {
   const [search, setSearch] = useState('')
   const [selected, setSelected] = useState<User | null>(null)
   const [creating, setCreating] = useState(false)
+  const [createOrigin, setCreateOrigin] = useState<DOMRect | null>(null)
+  const [detailOrigin, setDetailOrigin] = useState<DOMRect | null>(null)
   const { data, isLoading, error } = useUsers({ role: 'employee', search: search || undefined })
 
-  const employees = data?.items ?? []
-
-  if (selected) {
-    return <EmployeeDetail employee={selected} onBack={() => setSelected(null)} />
+  function openDetail(emp: User, e: { currentTarget: Element }) {
+    setDetailOrigin(e.currentTarget.getBoundingClientRect())
+    setSelected(emp)
   }
+
+  const employees = data?.items ?? []
 
   return (
     <div>
@@ -196,12 +196,17 @@ export function Employees() {
           <h2 className="text-xl font-semibold text-text">Empleados</h2>
           <p className="text-sm text-text-secondary mt-1">{data?.total ?? employees.length} miembros del equipo</p>
         </div>
-        <Button variant="primary" size="md" onClick={() => setCreating((v) => !v)}>
-          {creating ? 'Cerrar' : 'Agregar empleado'}
+        <Button
+          variant="primary"
+          size="md"
+          onClick={(e) => {
+            setCreateOrigin(e.currentTarget.getBoundingClientRect())
+            setCreating(true)
+          }}
+        >
+          Agregar empleado
         </Button>
       </div>
-
-      {creating && <CreateEmployeeForm onDone={() => setCreating(false)} />}
 
       <div className="relative mt-4">
         <div className="absolute inset-y-0 left-3 flex items-center pointer-events-none text-text-muted">
@@ -216,6 +221,7 @@ export function Employees() {
         />
       </div>
 
+      {/* Desktop table */}
       <Card className="mt-4 p-0 overflow-hidden hidden md:block">
         {isLoading ? (
           <div className="p-4 space-y-1">
@@ -237,39 +243,53 @@ export function Employees() {
                   <th className="text-left py-3 px-4 font-medium text-text-secondary">Rol</th>
                 </tr>
               </thead>
-              <tbody>
+              <motion.tbody initial="hidden" animate="visible" variants={staggerContainer}>
                 {employees.map((emp) => (
-                  <tr
+                  <motion.tr
                     key={emp.id}
+                    variants={staggerItem}
                     className="border-b border-border last:border-b-0 hover:bg-bg-subtle transition-colors cursor-pointer"
-                    onClick={() => setSelected(emp)}
+                    onClick={(e) => openDetail(emp, e)}
                   >
                     <td className="py-3 px-5"><span className="font-medium text-text">{emp.full_name}</span></td>
                     <td className="py-3 px-4 text-text-secondary">{emp.email}</td>
                     <td className="py-3 px-4">
                       <Badge variant="primary" badgeStyle="plain">{emp.role === 'admin' ? 'Admin' : 'Empleado'}</Badge>
                     </td>
-                  </tr>
+                  </motion.tr>
                 ))}
-              </tbody>
+              </motion.tbody>
             </table>
           </div>
         )}
       </Card>
 
-      <div className="mt-4 space-y-3 md:hidden">
+      {/* Mobile cards */}
+      <motion.div className="mt-4 space-y-3 md:hidden" initial="hidden" animate="visible" variants={staggerContainer}>
         {!isLoading && !error && employees.map((emp) => (
-          <Card key={emp.id} variant="interactive" onClick={() => setSelected(emp)}>
-            <div className="flex items-start justify-between gap-2">
-              <div className="min-w-0">
-                <p className="font-medium text-text truncate">{emp.full_name}</p>
-                <p className="text-sm text-text-secondary mt-0.5 truncate">{emp.email}</p>
+          <motion.div key={emp.id} variants={staggerItem}>
+            <Card variant="interactive" onClick={(e) => openDetail(emp, e)}>
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <p className="font-medium text-text truncate">{emp.full_name}</p>
+                  <p className="text-sm text-text-secondary mt-0.5 truncate">{emp.email}</p>
+                </div>
+                <Badge variant="primary" badgeStyle="plain">{emp.role === 'admin' ? 'Admin' : 'Empleado'}</Badge>
               </div>
-              <Badge variant="primary" badgeStyle="plain">{emp.role === 'admin' ? 'Admin' : 'Empleado'}</Badge>
-            </div>
-          </Card>
+            </Card>
+          </motion.div>
         ))}
-      </div>
+      </motion.div>
+
+      {/* Create-employee modal */}
+      <Modal open={creating} onClose={() => setCreating(false)} size="lg" origin={createOrigin}>
+        <CreateEmployeeForm onDone={() => setCreating(false)} />
+      </Modal>
+
+      {/* Employee-detail modal */}
+      <Modal open={!!selected} onClose={() => setSelected(null)} size="md" origin={detailOrigin}>
+        {selected && <EmployeeDetail employee={selected} />}
+      </Modal>
     </div>
   )
 }

--- a/apps/skillnet-web/src/pages/employee/CourseView.tsx
+++ b/apps/skillnet-web/src/pages/employee/CourseView.tsx
@@ -6,6 +6,9 @@ import { LessonContent } from '../../components/courses/LessonContent'
 import { ExerciseRenderer } from '../../components/exercises/ExerciseRenderer'
 import { useCourse } from '../../api/courses'
 import { useEnrollments } from '../../api/enrollments'
+import { slideVariants, staggerContainer, staggerItem, duration, ease, transition } from '../../lib/motion'
+
+const lessonSlide = slideVariants(48)
 
 function ChevronDown({ open }: { open: boolean }) {
   return (
@@ -28,6 +31,7 @@ export function CourseView() {
 
   const [expandedModules, setExpandedModules] = useState<Set<string>>(new Set())
   const [activeLessonId, setActiveLessonId] = useState<string>('')
+  const [direction, setDirection] = useState<1 | -1>(1)
 
   // Initialize expansion / active lesson once the course loads.
   useEffect(() => {
@@ -76,9 +80,19 @@ export function CourseView() {
     })
   }
 
+  // Switch lesson with a directional transition — forward slides in from the
+  // right, going back slides in from the left.
+  function selectLesson(lessonId: string) {
+    if (lessonId === activeLessonId) return
+    const targetIndex = allLessons.findIndex((l) => l.id === lessonId)
+    setDirection(targetIndex >= currentIndex ? 1 : -1)
+    setActiveLessonId(lessonId)
+  }
+
   function goToNext() {
     if (currentIndex < 0 || currentIndex >= allLessons.length - 1) return
     const nextLesson = allLessons[currentIndex + 1]
+    setDirection(1)
     setActiveLessonId(nextLesson.id)
     const parentModule = course!.modules.find((m) => m.lessons.some((l) => l.id === nextLesson.id))
     if (parentModule) setExpandedModules((prev) => new Set(prev).add(parentModule.id))
@@ -119,12 +133,13 @@ export function CourseView() {
                       <ChevronDown open={isExpanded} />
                     </button>
                     {isExpanded && (
-                      <div>
+                      <motion.div initial="hidden" animate="visible" variants={staggerContainer}>
                         {mod.lessons.map((lesson) => (
-                          <button
+                          <motion.button
                             key={lesson.id}
                             type="button"
-                            onClick={() => setActiveLessonId(lesson.id)}
+                            variants={staggerItem}
+                            onClick={() => selectLesson(lesson.id)}
                             className={`w-full text-left px-6 py-2.5 text-sm transition-colors border-b border-border last:border-b-0 ${
                               activeLessonId === lesson.id
                                 ? 'bg-primary-subtle text-primary font-medium'
@@ -132,9 +147,9 @@ export function CourseView() {
                             }`}
                           >
                             {lesson.title}
-                          </button>
+                          </motion.button>
                         ))}
-                      </div>
+                      </motion.div>
                     )}
                   </div>
                 )
@@ -144,14 +159,20 @@ export function CourseView() {
         </div>
 
         <div className="flex-1 min-w-0">
-          <AnimatePresence mode="wait">
+          <AnimatePresence mode="wait" custom={direction} initial={false}>
             {activeLesson && (
               <motion.div
                 key={activeLesson.id}
-                initial={{ opacity: 0, y: 8 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.2 }}
+                custom={direction}
+                variants={lessonSlide}
+                initial="enter"
+                animate="center"
+                exit="exit"
+                transition={{
+                  x: direction > 0 ? transition.pushIn : transition.pushOut,
+                  opacity: { duration: duration.normal, ease: ease.base },
+                  filter: { duration: duration.normal, ease: ease.base },
+                }}
               >
                 <Card>
                   <h3 className="text-base font-medium text-text mb-4">{activeLesson.title}</h3>

--- a/apps/skillnet-web/src/pages/employee/MyCourses.tsx
+++ b/apps/skillnet-web/src/pages/employee/MyCourses.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { motion } from 'framer-motion'
 import { Card, CardTitle, CourseItem, EmptyState, SkeletonRow } from '../../components/ui'
 import { useEnrollments } from '../../api/enrollments'
 import { ApiError } from '../../api/client'
+import { staggerContainer, staggerItem } from '../../lib/motion'
 import type { EnrollmentRead } from '../../types'
 
 type Tab = 'in_progress' | 'completed' | 'not_started'
@@ -85,18 +87,19 @@ export function MyCourses() {
         ) : (
           <>
             <CardTitle className="mb-2">{tabs.find((t) => t.key === activeTab)?.label}</CardTitle>
-            <div>
+            <motion.div key={activeTab} initial="hidden" animate="visible" variants={staggerContainer}>
               {filtered.map((e) => (
-                <CourseItem
-                  key={e.id}
-                  title={e.course_title}
-                  subtitle={subtitleFor(e)}
-                  progress={e.progress ?? 0}
-                  color="var(--color-primary)"
-                  onClick={() => navigate(`/empleado/curso/${e.course_id}`)}
-                />
+                <motion.div key={e.id} variants={staggerItem}>
+                  <CourseItem
+                    title={e.course_title}
+                    subtitle={subtitleFor(e)}
+                    progress={e.progress ?? 0}
+                    color="var(--color-primary)"
+                    onClick={() => navigate(`/empleado/curso/${e.course_id}`)}
+                  />
+                </motion.div>
               ))}
-            </div>
+            </motion.div>
           </>
         )}
       </Card>


### PR DESCRIPTION
…ive modals

Implements the prioritized motion-system backlog (docs/design/motion-system.md):
- Signature-curve page transitions (blur + scale) in AppLayout/AdminLayout
- Shared-layout nav pill (layoutId) that fuses with the content edge, on both the employee and admin sidebars
- Native modals (new Modal component) that grow from their trigger via FLIP, with a frosted full-screen backdrop and content that blurs in — modeled on stepbro.site's window language
- Staggered lists (employees, courses, lessons)
- Button/Card micro-interactions (scale hover/tap, hover elevation)
- Directional blur transition on lesson change in CourseView
- Wizard slide with blur + enter-slow/exit-fast asymmetry
- Mobile hamburger + frosted spring sidebar overlay
- CSS motion tokens (easing vars), .glass-panel, GPU hints