### PR TITLE
refactor(web): lighter page transition, sliding tab indicator, animat…

### DIFF
--- a/apps/skillnet-web/src/components/layout/Header.tsx
+++ b/apps/skillnet-web/src/components/layout/Header.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
-import { motion } from 'framer-motion'
+import { motion, AnimatePresence } from 'framer-motion'
 import { useMe, useLogout } from '../../api/auth'
 import { useSidebar } from '../../contexts/SidebarContext'
-import { transition } from '../../lib/motion'
+import { transition, duration, ease } from '../../lib/motion'
 
 export function Header() {
   const { data: user } = useMe()
@@ -41,42 +41,53 @@ export function Header() {
       </motion.button>
 
       <div className="relative" ref={menuRef}>
-        <button
+        <motion.button
           type="button"
           onClick={() => setOpen((v) => !v)}
-          className="w-8 h-8 rounded-full border border-white/30 flex items-center justify-center text-white hover:border-white/60 transition-colors"
+          className="w-8 h-8 rounded-full border border-white/30 flex items-center justify-center text-white hover:border-white/60 transition-colors cursor-pointer"
           aria-label="Cuenta"
           aria-haspopup="menu"
           aria-expanded={open}
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.92 }}
+          transition={transition.micro}
         >
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
             <circle cx="12" cy="7" r="4" />
           </svg>
-        </button>
+        </motion.button>
 
-        {open && (
-          <div
-            role="menu"
-            className="absolute right-0 top-11 w-56 bg-bg border border-border rounded-lg shadow-lg overflow-hidden"
-          >
-            {user && (
-              <div className="px-4 py-3 border-b border-border">
-                <p className="text-sm font-medium text-text truncate">{user.full_name}</p>
-                <p className="text-xs text-text-muted truncate">{user.email}</p>
-              </div>
-            )}
-            <button
-              type="button"
-              role="menuitem"
-              onClick={() => logout.mutate()}
-              disabled={logout.isPending}
-              className="w-full text-left px-4 py-2.5 text-sm text-text hover:bg-bg-muted transition-colors disabled:opacity-50 cursor-pointer"
+        <AnimatePresence>
+          {open && (
+            <motion.div
+              role="menu"
+              initial={{ opacity: 0, scale: 0.95, y: -6, filter: 'blur(4px)' }}
+              animate={{ opacity: 1, scale: 1, y: 0, filter: 'blur(0px)' }}
+              exit={{ opacity: 0, scale: 0.96, y: -6, filter: 'blur(4px)' }}
+              transition={{ duration: duration.fast, ease: ease.base }}
+              className="absolute right-0 top-11 w-56 origin-top-right bg-bg border border-border rounded-xl shadow-lg overflow-hidden"
             >
-              {logout.isPending ? 'Cerrando...' : 'Cerrar sesion'}
-            </button>
-          </div>
-        )}
+              {user && (
+                <div className="px-4 py-3 border-b border-border">
+                  <p className="text-sm font-medium text-text truncate">{user.full_name}</p>
+                  <p className="text-xs text-text-muted truncate">{user.email}</p>
+                </div>
+              )}
+              <motion.button
+                type="button"
+                role="menuitem"
+                onClick={() => logout.mutate()}
+                disabled={logout.isPending}
+                className="w-full text-left px-4 py-2.5 text-sm text-text hover:bg-bg-muted transition-colors disabled:opacity-50 cursor-pointer"
+                whileTap={{ scale: 0.98 }}
+                transition={transition.micro}
+              >
+                {logout.isPending ? 'Cerrando...' : 'Cerrar sesion'}
+              </motion.button>
+            </motion.div>
+          )}
+        </AnimatePresence>
       </div>
     </header>
   )

--- a/apps/skillnet-web/src/components/ui/Button.tsx
+++ b/apps/skillnet-web/src/components/ui/Button.tsx
@@ -10,16 +10,11 @@ export interface ButtonProps extends HTMLMotionProps<'button'> {
 }
 
 const variantClasses: Record<ButtonVariant, string> = {
-  primary:
-    'bg-primary hover:bg-primary-hover text-white',
-  secondary:
-    'border border-border hover:bg-bg-muted text-text',
-  ghost:
-    'hover:bg-bg-muted text-text-secondary',
-  accent:
-    'bg-accent hover:bg-accent-hover text-white',
-  danger:
-    'bg-danger hover:bg-danger/90 text-white',
+  primary: 'bg-primary hover:bg-primary-hover text-white',
+  secondary: 'border border-border hover:bg-bg-muted text-text',
+  ghost: 'hover:bg-bg-muted text-text-secondary',
+  accent: 'bg-accent hover:bg-accent-hover text-white',
+  danger: 'bg-danger hover:bg-danger/90 text-white',
 }
 
 const sizeClasses: Record<ButtonSize, string> = {
@@ -48,7 +43,7 @@ export function Button({
         ${className}
       `}
       disabled={disabled}
-      whileHover={disabled ? undefined : { scale: 1.03 }}
+      whileHover={disabled ? undefined : { scale: 1.02 }}
       whileTap={disabled ? undefined : { scale: 0.97 }}
       transition={transition.micro}
       {...props}

--- a/apps/skillnet-web/src/lib/motion.ts
+++ b/apps/skillnet-web/src/lib/motion.ts
@@ -53,8 +53,8 @@ export const spring = {
 
 // ── Reusable transition presets ──────────────────────────────
 export const transition = {
-  /** Page/route transitions */
-  page: { duration: duration.medium, ease: ease.base },
+  /** Page/route transitions — quick blur-in, no scale (keeps nav snappy) */
+  page: { duration: duration.normal, ease: ease.base },
   /** Content swap within a page (lesson switch, tab change) */
   content: { duration: duration.normal, ease: ease.base },
   /** Layout morph (layoutId transitions) */
@@ -69,11 +69,15 @@ export const transition = {
 
 // ── Reusable animation states ────────────────────────────────
 
-/** Page transition: blur + scale entrance */
+/**
+ * Page transition: quick blur-in (no scale). The scale read as "too much" on
+ * every route change; blur alone keeps the iOS depth-of-field feel while staying
+ * snappy and not competing with the sliding nav pill.
+ */
 export const pageTransition = {
-  initial: { opacity: 0, filter: 'blur(8px)', scale: 0.98 },
-  animate: { opacity: 1, filter: 'blur(0px)', scale: 1 },
-  exit: { opacity: 0, filter: 'blur(8px)', scale: 0.98 },
+  initial: { opacity: 0, filter: 'blur(6px)' },
+  animate: { opacity: 1, filter: 'blur(0px)' },
+  exit: { opacity: 0, filter: 'blur(6px)' },
   transition: transition.page,
 } as const
 

--- a/apps/skillnet-web/src/pages/admin/CreateCourse.tsx
+++ b/apps/skillnet-web/src/pages/admin/CreateCourse.tsx
@@ -432,7 +432,7 @@ export function CreateCourse() {
       </div>
 
       <div className="mt-6 overflow-hidden">
-        <AnimatePresence mode="wait" custom={direction}>
+        <AnimatePresence mode="wait" custom={direction} initial={false}>
           <motion.div key={step} custom={direction} variants={slideVariants} initial="enter" animate="center" exit="exit">
             {renderStep()}
           </motion.div>

--- a/apps/skillnet-web/src/pages/dev/MotionDemo.tsx
+++ b/apps/skillnet-web/src/pages/dev/MotionDemo.tsx
@@ -81,7 +81,7 @@ function PageTransitionDemo() {
           </div>
           <div>
             <p className="font-medium mb-1">Ahora:</p>
-            <code className="block bg-bg-muted rounded p-2">opacity: 0, blur: 8px, scale: 0.98, duration: 0.5</code>
+            <code className="block bg-bg-muted rounded p-2">opacity: 0, blur: 6px, duration: 0.3, curva firma</code>
           </div>
         </div>
       </details>
@@ -528,7 +528,7 @@ function ComparisonDemo() {
                 className="absolute inset-0 flex items-center justify-center"
                 {...pageTransition}
               >
-                <p className="text-sm text-text-secondary">blur + scale, 0.5s, curva firma</p>
+                <p className="text-sm text-text-secondary">blur + fade, 0.3s, curva firma</p>
               </motion.div>
             </AnimatePresence>
           </div>

--- a/apps/skillnet-web/src/pages/employee/MyCourses.tsx
+++ b/apps/skillnet-web/src/pages/employee/MyCourses.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { motion } from 'framer-motion'
+import { motion, LayoutGroup } from 'framer-motion'
 import { Card, CardTitle, CourseItem, EmptyState, SkeletonRow } from '../../components/ui'
 import { useEnrollments } from '../../api/enrollments'
 import { ApiError } from '../../api/client'
-import { staggerContainer, staggerItem } from '../../lib/motion'
+import { staggerContainer, staggerItem, spring } from '../../lib/motion'
 import type { EnrollmentRead } from '../../types'
 
 type Tab = 'in_progress' | 'completed' | 'not_started'
@@ -48,22 +48,32 @@ export function MyCourses() {
     <div>
       <h2 className="text-xl font-semibold text-text mb-6">Mis Cursos</h2>
 
-      <div className="flex gap-1 mb-6 border-b border-border overflow-x-auto">
-        {tabs.map((tab) => (
-          <button
-            key={tab.key}
-            type="button"
-            onClick={() => setActiveTab(tab.key)}
-            className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px whitespace-nowrap shrink-0 ${
-              activeTab === tab.key
-                ? 'border-primary text-primary'
-                : 'border-transparent text-text-secondary hover:text-text'
-            }`}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
+      <LayoutGroup>
+        <div className="flex gap-1 mb-6 border-b border-border">
+          {tabs.map((tab) => {
+            const active = activeTab === tab.key
+            return (
+              <button
+                key={tab.key}
+                type="button"
+                onClick={() => setActiveTab(tab.key)}
+                className={`relative px-4 py-2 text-sm font-medium transition-colors whitespace-nowrap ${
+                  active ? 'text-primary' : 'text-text-secondary hover:text-text'
+                }`}
+              >
+                {tab.label}
+                {active && (
+                  <motion.span
+                    layoutId="mycourses-tab-underline"
+                    className="absolute left-3 right-3 -bottom-px h-0.5 rounded-full bg-primary"
+                    transition={spring.stiff}
+                  />
+                )}
+              </button>
+            )
+          })}
+        </div>
+      </LayoutGroup>
 
       <Card>
         {isLoading ? (


### PR DESCRIPTION
…ed header menu

Refinements after live review:
- Page transition: drop the scale — blur-only 0.3s. The scale read as too heavy on every route change; blur keeps the iOS depth without competing with the sliding nav pill.
- Buttons: revert the ripple experiment; keep just the subtle scale press (the ripple collided with the modal growing from the same button and clashed with the iOS/frosted direction).
- MyCourses: sliding tab indicator via layoutId + remove the stray horizontal scrollbar on the tab bar.
- CreateCourse: wizard no longer slides on entry (only between steps), so the page feels consistent with the rest.
- Header: animate the account button (scale) and its dropdown (fade + scale + blur from the top-right).