### PR TITLE
feat: A2A agent server + skills service + external API

### DIFF
--- a/apps/skillnet-a2a/pyproject.toml
+++ b/apps/skillnet-a2a/pyproject.toml
@@ -1,0 +1,34 @@
+[project]
+name = "skillnet-a2a"
+version = "0.1.0"
+description = "SkillNet A2A agent server"
+requires-python = ">=3.12"
+dependencies = [
+    "a2a-sdk",
+    "httpx",
+    "litellm<1.92",
+    "pydantic>=2",
+    "pydantic-settings",
+    "uvicorn[standard]",
+    "starlette",
+]
+
+[dependency-groups]
+dev = [
+    "pytest",
+    "pytest-asyncio",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/apps/skillnet-a2a/src/a2a_client.py
+++ b/apps/skillnet-a2a/src/a2a_client.py
@@ -1,0 +1,57 @@
+"""Simple A2A client for testing the SkillNet agent."""
+
+import httpx
+
+
+class SkillNetA2AClient:
+    """Client that sends messages to the SkillNet A2A server."""
+
+    def __init__(self, url: str = "http://localhost:5000", auth_key: str = "") -> None:
+        self.url = url.rstrip("/")
+        self.auth_key = auth_key
+
+    async def get_agent_card(self) -> dict:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{self.url}/.well-known/agent.json")
+            resp.raise_for_status()
+            return resp.json()
+
+    async def send_message(self, text: str, task_id: str | None = None) -> dict:
+        headers = {}
+        if self.auth_key:
+            headers["Authorization"] = f"Bearer {self.auth_key}"
+
+        payload = {
+            "jsonrpc": "2.0",
+            "method": "message/send",
+            "params": {
+                "id": task_id,
+                "message": {
+                    "role": "user",
+                    "parts": [{"type": "text", "text": text}],
+                },
+            },
+            "id": 1,
+        }
+
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            resp = await client.post(self.url, json=payload, headers=headers)
+            resp.raise_for_status()
+            return resp.json()
+
+    async def get_task(self, task_id: str) -> dict:
+        headers = {}
+        if self.auth_key:
+            headers["Authorization"] = f"Bearer {self.auth_key}"
+
+        payload = {
+            "jsonrpc": "2.0",
+            "method": "tasks/get",
+            "params": {"id": task_id},
+            "id": 2,
+        }
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(self.url, json=payload, headers=headers)
+            resp.raise_for_status()
+            return resp.json()

--- a/apps/skillnet-a2a/src/agent_card.py
+++ b/apps/skillnet-a2a/src/agent_card.py
@@ -1,0 +1,64 @@
+"""AgentCard definition for the SkillNet A2A server."""
+
+from src.config import settings
+
+AGENT_CARD = {
+    "name": "SkillNet",
+    "description": (
+        "AI-native training platform agent. Query employee skills, "
+        "find experts, analyze skill gaps, and verify learning achievements."
+    ),
+    "url": settings.A2A_AGENT_URL,
+    "version": "0.1.0",
+    "capabilities": {
+        "streaming": False,
+        "pushNotifications": False,
+    },
+    "skills": [
+        {
+            "id": "who_knows",
+            "name": "Find who knows a skill",
+            "description": "Find employees who have a specific skill at a given proficiency level",
+            "examples": [
+                "Who knows Python?",
+                "Find employees skilled in customer service at high level",
+            ],
+        },
+        {
+            "id": "get_gap",
+            "name": "Analyze skill gaps",
+            "description": "Identify skills with low coverage across the organization",
+            "examples": [
+                "What are our biggest skill gaps?",
+                "Which skills need more training?",
+            ],
+        },
+        {
+            "id": "verify_skill",
+            "name": "Verify employee skill",
+            "description": "Record or confirm an employee's proficiency in a skill",
+            "examples": [
+                "Confirm Maria knows food safety at medium level",
+                "Record that Juan has completed Python training",
+            ],
+        },
+        {
+            "id": "list_skills",
+            "name": "List skill taxonomy",
+            "description": "Show all skills organized by category",
+            "examples": ["What skills do we track?", "Show me the skill categories"],
+        },
+        {
+            "id": "get_user_skills",
+            "name": "Get employee skills",
+            "description": "Get the complete skill profile of an employee",
+            "examples": [
+                "What skills does Maria have?",
+                "Show Juan's skill profile",
+            ],
+        },
+    ],
+    "authentication": {
+        "schemes": ["bearer"],
+    },
+}

--- a/apps/skillnet-a2a/src/config.py
+++ b/apps/skillnet-a2a/src/config.py
@@ -1,0 +1,24 @@
+"""Configuration loaded from environment variables."""
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    # SkillNet API connection
+    API_URL: str = "http://localhost:8000"
+    SKILLNET_API_KEY: str = ""
+
+    # LLM for the orchestrator
+    LLM_BASE_URL: str = "https://api.openai.com/v1"
+    LLM_API_KEY: str = ""
+    LLM_MODEL: str = "gpt-4o-mini"
+
+    # A2A server
+    A2A_PORT: int = 5000
+    A2A_AUTH_KEY: str = ""  # bearer token external agents must provide
+    A2A_AGENT_URL: str = "http://localhost:5000"
+
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+
+settings = Settings()

--- a/apps/skillnet-a2a/src/main.py
+++ b/apps/skillnet-a2a/src/main.py
@@ -1,0 +1,156 @@
+"""SkillNet A2A Server — JSON-RPC 2.0 over HTTP."""
+
+import json
+import logging
+import uuid
+
+import uvicorn
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+from src.agent_card import AGENT_CARD
+from src.config import settings
+from src.orchestrator import run as orchestrator_run
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("skillnet-a2a")
+
+
+async def agent_card(request: Request) -> JSONResponse:
+    """Serve the AgentCard at /.well-known/agent.json"""
+    return JSONResponse(AGENT_CARD)
+
+
+def _verify_auth(request: Request) -> bool:
+    """Verify bearer token if A2A_AUTH_KEY is configured."""
+    if not settings.A2A_AUTH_KEY:
+        return True  # no auth configured
+    auth = request.headers.get("authorization", "")
+    if not auth.startswith("Bearer "):
+        return False
+    return auth.removeprefix("Bearer ").strip() == settings.A2A_AUTH_KEY
+
+
+async def jsonrpc_handler(request: Request) -> JSONResponse:
+    """Handle JSON-RPC 2.0 requests following the A2A protocol."""
+    if not _verify_auth(request):
+        return JSONResponse(
+            {"jsonrpc": "2.0", "error": {"code": -32000, "message": "Unauthorized"}, "id": None},
+            status_code=401,
+        )
+
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(
+            {"jsonrpc": "2.0", "error": {"code": -32700, "message": "Parse error"}, "id": None},
+            status_code=400,
+        )
+
+    method = body.get("method", "")
+    params = body.get("params", {})
+    rpc_id = body.get("id")
+
+    if method == "message/send":
+        return await _handle_message_send(params, rpc_id)
+    elif method == "tasks/get":
+        return await _handle_task_get(params, rpc_id)
+    else:
+        return JSONResponse({
+            "jsonrpc": "2.0",
+            "error": {"code": -32601, "message": f"Method not found: {method}"},
+            "id": rpc_id,
+        })
+
+
+# In-memory task store (good enough for v0)
+_tasks: dict[str, dict] = {}
+
+
+async def _handle_message_send(params: dict, rpc_id: str | int | None) -> JSONResponse:
+    """Handle message/send: run the orchestrator and return the result."""
+    message = params.get("message", {})
+    task_id = params.get("id") or str(uuid.uuid4())
+
+    # Extract text from message parts
+    parts = message.get("parts", [])
+    text_parts = [p.get("text", "") for p in parts if p.get("type") == "text"]
+    user_text = " ".join(text_parts).strip()
+
+    if not user_text:
+        # Try plain text field
+        user_text = message.get("text", "")
+
+    if not user_text:
+        return JSONResponse({
+            "jsonrpc": "2.0",
+            "error": {"code": -32602, "message": "No text content in message"},
+            "id": rpc_id,
+        })
+
+    logger.info("Task %s: processing message: %s", task_id, user_text[:100])
+
+    try:
+        result_text = await orchestrator_run(user_text)
+    except Exception as exc:
+        logger.error("Orchestrator failed: %s", exc)
+        _tasks[task_id] = {"id": task_id, "status": {"state": "failed"}}
+        return JSONResponse({
+            "jsonrpc": "2.0",
+            "error": {"code": -32000, "message": f"Agent error: {exc}"},
+            "id": rpc_id,
+        })
+
+    task = {
+        "id": task_id,
+        "status": {"state": "completed"},
+        "artifacts": [
+            {
+                "parts": [{"type": "text", "text": result_text}],
+            }
+        ],
+    }
+    _tasks[task_id] = task
+
+    return JSONResponse({
+        "jsonrpc": "2.0",
+        "result": task,
+        "id": rpc_id,
+    })
+
+
+async def _handle_task_get(params: dict, rpc_id: str | int | None) -> JSONResponse:
+    """Handle tasks/get: return a stored task by ID."""
+    task_id = params.get("id", "")
+    task = _tasks.get(task_id)
+    if task is None:
+        return JSONResponse({
+            "jsonrpc": "2.0",
+            "error": {"code": -32602, "message": f"Task not found: {task_id}"},
+            "id": rpc_id,
+        })
+    return JSONResponse({"jsonrpc": "2.0", "result": task, "id": rpc_id})
+
+
+app = Starlette(
+    routes=[
+        Route("/.well-known/agent.json", agent_card, methods=["GET"]),
+        Route("/", jsonrpc_handler, methods=["POST"]),
+    ],
+)
+
+
+def main() -> None:
+    uvicorn.run(
+        "src.main:app",
+        host="0.0.0.0",
+        port=settings.A2A_PORT,
+        reload=False,
+        log_level="info",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/skillnet-a2a/src/orchestrator.py
+++ b/apps/skillnet-a2a/src/orchestrator.py
@@ -1,0 +1,83 @@
+"""LLM orchestrator: interprets natural language, calls tools, returns answers."""
+
+import json
+import logging
+
+import litellm
+
+from src.config import settings
+from src.tools import TOOL_DEFINITIONS, execute_tool
+
+logger = logging.getLogger(__name__)
+
+SYSTEM_PROMPT = """\
+You are SkillNet's agent — an AI training platform for companies.
+You help external agents and systems query employee skills, identify skill gaps,
+and verify learning achievements.
+
+You have access to the following capabilities:
+- Find who knows a specific skill (who_knows)
+- Analyze skill gaps across the organization (get_gap)
+- Verify/record an employee's skill level (verify_skill)
+- List the skill taxonomy (list_skills)
+- Get an employee's skill profile (get_user_skills)
+
+Always respond in the same language as the user's message.
+Be concise and structured in your responses.
+If you cannot fulfill a request with the available tools, explain what you can do instead.
+"""
+
+MAX_TOOL_ROUNDS = 5
+
+
+async def run(message: str) -> str:
+    """Process a natural language message and return a response.
+
+    Uses a tool-calling loop: the LLM decides which tools to call,
+    we execute them and feed results back, until the LLM produces
+    a final text response.
+    """
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": message},
+    ]
+
+    for _round in range(MAX_TOOL_ROUNDS):
+        response = await litellm.acompletion(
+            model=settings.LLM_MODEL,
+            messages=messages,
+            tools=TOOL_DEFINITIONS,
+            api_key=settings.LLM_API_KEY,
+            api_base=settings.LLM_BASE_URL if settings.LLM_BASE_URL else None,
+            temperature=0.1,
+        )
+
+        choice = response.choices[0]
+
+        # If no tool calls, we have the final answer
+        if not choice.message.tool_calls:
+            return choice.message.content or ""
+
+        # Process tool calls
+        messages.append(choice.message.model_dump())
+
+        for tool_call in choice.message.tool_calls:
+            fn_name = tool_call.function.name
+            fn_args = json.loads(tool_call.function.arguments)
+
+            logger.info("Tool call: %s(%s)", fn_name, fn_args)
+
+            try:
+                result = await execute_tool(fn_name, fn_args)
+            except Exception as exc:
+                logger.error("Tool %s failed: %s", fn_name, exc)
+                result = json.dumps({"error": str(exc)})
+
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tool_call.id,
+                "content": result,
+            })
+
+    # Safety: if we exhaust rounds, return what we have
+    return "I was unable to complete the request within the allowed number of steps."

--- a/apps/skillnet-a2a/src/skillnet_client.py
+++ b/apps/skillnet-a2a/src/skillnet_client.py
@@ -1,0 +1,65 @@
+"""Async HTTP client for the SkillNet external API."""
+
+import uuid
+
+import httpx
+
+from src.config import settings
+
+
+class SkillNetClient:
+    """Thin wrapper over SkillNet /ext/v1/ endpoints."""
+
+    def __init__(self) -> None:
+        self._base = settings.API_URL.rstrip("/")
+        self._headers = {"Authorization": f"Bearer {settings.SKILLNET_API_KEY}"}
+
+    def _client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            base_url=self._base,
+            headers=self._headers,
+            timeout=30.0,
+        )
+
+    async def who_knows(self, skill: str, min_level: str | None = None) -> dict:
+        async with self._client() as client:
+            params: dict = {"skill": skill}
+            if min_level:
+                params["min_level"] = min_level
+            resp = await client.get("/ext/v1/skills/who-knows", params=params)
+            resp.raise_for_status()
+            return resp.json()
+
+    async def get_gap(self) -> dict:
+        async with self._client() as client:
+            resp = await client.get("/ext/v1/skills/gaps")
+            resp.raise_for_status()
+            return resp.json()
+
+    async def verify_skill(
+        self, user_id: str, skill_name: str, level: str, source: str = "manual"
+    ) -> dict:
+        async with self._client() as client:
+            resp = await client.post(
+                "/ext/v1/skills/verify",
+                json={
+                    "user_id": user_id,
+                    "skill_name": skill_name,
+                    "level": level,
+                    "source": source,
+                },
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+    async def list_skills(self) -> dict:
+        async with self._client() as client:
+            resp = await client.get("/ext/v1/skills")
+            resp.raise_for_status()
+            return resp.json()
+
+    async def get_user_skills(self, user_id: str) -> dict:
+        async with self._client() as client:
+            resp = await client.get(f"/ext/v1/skills/users/{user_id}/skills")
+            resp.raise_for_status()
+            return resp.json()

--- a/apps/skillnet-a2a/src/tools.py
+++ b/apps/skillnet-a2a/src/tools.py
@@ -1,0 +1,129 @@
+"""Tool definitions and executors for the SkillNet A2A orchestrator."""
+
+import json
+from typing import Any
+
+from src.skillnet_client import SkillNetClient
+
+TOOL_DEFINITIONS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "who_knows",
+            "description": "Find employees who have a specific skill. Returns a list of employees with their proficiency level.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "skill": {
+                        "type": "string",
+                        "description": "The skill name to search for (e.g., 'Python', 'atencion_cliente', 'sushi')",
+                    },
+                    "min_level": {
+                        "type": "string",
+                        "enum": ["low", "medium", "high"],
+                        "description": "Minimum proficiency level to filter by. Optional.",
+                    },
+                },
+                "required": ["skill"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_gap",
+            "description": "Analyze skill gaps across the organization. Shows which skills have low coverage and need attention.",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "verify_skill",
+            "description": "Record or update an employee's skill level. Use this to confirm that an employee has demonstrated a skill at a certain level.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "user_id": {
+                        "type": "string",
+                        "description": "The UUID of the employee",
+                    },
+                    "skill_name": {
+                        "type": "string",
+                        "description": "The skill to verify",
+                    },
+                    "level": {
+                        "type": "string",
+                        "enum": ["low", "medium", "high"],
+                        "description": "The proficiency level",
+                    },
+                    "source": {
+                        "type": "string",
+                        "description": "How the skill was verified (e.g., 'manual', 'checkpoint', 'external_assessment')",
+                        "default": "manual",
+                    },
+                },
+                "required": ["user_id", "skill_name", "level"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "list_skills",
+            "description": "List all skills in the organization's taxonomy, grouped by category.",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_user_skills",
+            "description": "Get the complete skill profile of a specific employee.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "user_id": {
+                        "type": "string",
+                        "description": "The UUID of the employee",
+                    },
+                },
+                "required": ["user_id"],
+            },
+        },
+    },
+]
+
+
+async def execute_tool(name: str, arguments: dict[str, Any]) -> str:
+    """Execute a tool call and return the result as a JSON string."""
+    client = SkillNetClient()
+
+    if name == "who_knows":
+        result = await client.who_knows(
+            skill=arguments["skill"],
+            min_level=arguments.get("min_level"),
+        )
+    elif name == "get_gap":
+        result = await client.get_gap()
+    elif name == "verify_skill":
+        result = await client.verify_skill(
+            user_id=arguments["user_id"],
+            skill_name=arguments["skill_name"],
+            level=arguments["level"],
+            source=arguments.get("source", "manual"),
+        )
+    elif name == "list_skills":
+        result = await client.list_skills()
+    elif name == "get_user_skills":
+        result = await client.get_user_skills(user_id=arguments["user_id"])
+    else:
+        result = {"error": f"Unknown tool: {name}"}
+
+    return json.dumps(result, ensure_ascii=False)

--- a/apps/skillnet-a2a/tests/test_orchestrator.py
+++ b/apps/skillnet-a2a/tests/test_orchestrator.py
@@ -1,0 +1,166 @@
+"""Tests for the A2A orchestrator tool dispatch."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_skillnet_client():
+    """Mock SkillNetClient responses."""
+    with patch("src.tools.SkillNetClient") as mock_cls:
+        client = mock_cls.return_value
+        client.who_knows = AsyncMock(return_value={
+            "items": [
+                {"user_id": "abc-123", "full_name": "Maria Lopez", "level": "high"},
+                {"user_id": "def-456", "full_name": "Juan Garcia", "level": "medium"},
+            ],
+            "total": 2,
+        })
+        client.get_gap = AsyncMock(return_value={
+            "gaps": [
+                {"skill": "Python", "total_users": 10, "coverage": {"high": 1, "medium": 2, "low": 3, "none": 4}},
+                {"skill": "SQL", "total_users": 10, "coverage": {"high": 0, "medium": 1, "low": 2, "none": 7}},
+            ]
+        })
+        client.verify_skill = AsyncMock(return_value={
+            "user_id": "abc-123",
+            "skill": "Python",
+            "level": "high",
+            "source": "manual",
+        })
+        client.list_skills = AsyncMock(return_value={
+            "categories": [
+                {"name": "Tech", "skills": [{"name": "Python"}, {"name": "SQL"}]},
+            ]
+        })
+        client.get_user_skills = AsyncMock(return_value={
+            "user_id": "abc-123",
+            "skills": [
+                {"name": "Python", "level": "high"},
+                {"name": "SQL", "level": "medium"},
+            ]
+        })
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_who_knows(mock_skillnet_client):
+    """Tool executor should call who_knows with correct args."""
+    from src.tools import execute_tool
+
+    result = await execute_tool("who_knows", {"skill": "Python", "min_level": "medium"})
+    parsed = json.loads(result)
+
+    mock_skillnet_client.who_knows.assert_awaited_once_with(
+        skill="Python", min_level="medium"
+    )
+    assert parsed["total"] == 2
+    assert len(parsed["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_get_gap(mock_skillnet_client):
+    """Tool executor should call get_gap."""
+    from src.tools import execute_tool
+
+    result = await execute_tool("get_gap", {})
+    parsed = json.loads(result)
+
+    mock_skillnet_client.get_gap.assert_awaited_once()
+    assert len(parsed["gaps"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_verify_skill(mock_skillnet_client):
+    """Tool executor should call verify_skill with correct args."""
+    from src.tools import execute_tool
+
+    result = await execute_tool("verify_skill", {
+        "user_id": "abc-123",
+        "skill_name": "Python",
+        "level": "high",
+        "source": "manual",
+    })
+    parsed = json.loads(result)
+
+    mock_skillnet_client.verify_skill.assert_awaited_once_with(
+        user_id="abc-123",
+        skill_name="Python",
+        level="high",
+        source="manual",
+    )
+    assert parsed["level"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_list_skills(mock_skillnet_client):
+    """Tool executor should call list_skills."""
+    from src.tools import execute_tool
+
+    result = await execute_tool("list_skills", {})
+    parsed = json.loads(result)
+
+    mock_skillnet_client.list_skills.assert_awaited_once()
+    assert "categories" in parsed
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_get_user_skills(mock_skillnet_client):
+    """Tool executor should call get_user_skills."""
+    from src.tools import execute_tool
+
+    result = await execute_tool("get_user_skills", {"user_id": "abc-123"})
+    parsed = json.loads(result)
+
+    mock_skillnet_client.get_user_skills.assert_awaited_once_with(user_id="abc-123")
+    assert len(parsed["skills"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_unknown():
+    """Unknown tool should return error."""
+    from src.tools import execute_tool
+
+    result = await execute_tool("nonexistent_tool", {})
+    parsed = json.loads(result)
+
+    assert "error" in parsed
+    assert "nonexistent_tool" in parsed["error"]
+
+
+@pytest.mark.asyncio
+async def test_agent_card_endpoint():
+    """AgentCard endpoint should return valid card."""
+    from starlette.testclient import TestClient
+    from src.main import app
+
+    client = TestClient(app)
+    resp = client.get("/.well-known/agent.json")
+
+    assert resp.status_code == 200
+    card = resp.json()
+    assert card["name"] == "SkillNet"
+    assert len(card["skills"]) == 5
+    assert card["capabilities"]["streaming"] is False
+
+
+@pytest.mark.asyncio
+async def test_jsonrpc_method_not_found():
+    """Unknown JSON-RPC method should return error."""
+    from starlette.testclient import TestClient
+    from src.main import app
+
+    client = TestClient(app)
+    resp = client.post("/", json={
+        "jsonrpc": "2.0",
+        "method": "unknown/method",
+        "params": {},
+        "id": 1,
+    })
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == -32601

--- a/apps/skillnet-api/alembic/versions/0003_add_skills_and_api_keys.py
+++ b/apps/skillnet-api/alembic/versions/0003_add_skills_and_api_keys.py
@@ -1,0 +1,112 @@
+"""add skill_categories, skills, user_skills, and api_keys tables
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-07-21
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0003"
+down_revision: str | None = "0002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # --- Enum ---
+    skill_level = sa.Enum("low", "medium", "high", name="skill_level")
+    skill_level.create(op.get_bind(), checkfirst=True)
+
+    # --- skill_categories ---
+    op.create_table(
+        "skill_categories",
+        sa.Column("id", sa.Uuid(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("org_id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("position", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["org_id"], ["organizations.id"]),
+        sa.UniqueConstraint("org_id", "name", name="uq_skill_categories_org_name"),
+    )
+
+    # --- skills ---
+    op.create_table(
+        "skills",
+        sa.Column("id", sa.Uuid(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("org_id", sa.Uuid(), nullable=False),
+        sa.Column("category_id", sa.Uuid(), nullable=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["org_id"], ["organizations.id"]),
+        sa.ForeignKeyConstraint(["category_id"], ["skill_categories.id"]),
+        sa.UniqueConstraint("org_id", "name", name="uq_skills_org_name"),
+    )
+    op.create_index("idx_skills_org", "skills", ["org_id"])
+
+    # --- user_skills ---
+    op.create_table(
+        "user_skills",
+        sa.Column("id", sa.Uuid(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("skill_id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "level",
+            sa.Enum("low", "medium", "high", name="skill_level", create_type=False),
+            nullable=False,
+            server_default="low",
+        ),
+        sa.Column("source", sa.String(), nullable=False, server_default="checkpoint"),
+        sa.Column("last_assessed_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["skill_id"], ["skills.id"]),
+        sa.UniqueConstraint("user_id", "skill_id", name="uq_user_skills_user_skill"),
+    )
+    op.create_index("idx_user_skills_user", "user_skills", ["user_id"])
+    op.create_index("idx_user_skills_skill", "user_skills", ["skill_id"])
+
+    # --- api_keys ---
+    op.create_table(
+        "api_keys",
+        sa.Column("id", sa.Uuid(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("org_id", sa.Uuid(), nullable=False),
+        sa.Column("created_by", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("key_hash", sa.String(), nullable=False),
+        sa.Column("scopes", sa.ARRAY(sa.String()), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("last_used_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["org_id"], ["organizations.id"]),
+        sa.ForeignKeyConstraint(["created_by"], ["users.id"]),
+    )
+    op.create_index("idx_api_keys_org", "api_keys", ["org_id"])
+    op.create_index("idx_api_keys_hash", "api_keys", ["key_hash"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_api_keys_hash", table_name="api_keys")
+    op.drop_index("idx_api_keys_org", table_name="api_keys")
+    op.drop_table("api_keys")
+
+    op.drop_index("idx_user_skills_skill", table_name="user_skills")
+    op.drop_index("idx_user_skills_user", table_name="user_skills")
+    op.drop_table("user_skills")
+
+    op.drop_index("idx_skills_org", table_name="skills")
+    op.drop_table("skills")
+
+    op.drop_table("skill_categories")
+
+    sa.Enum(name="skill_level").drop(op.get_bind(), checkfirst=True)

--- a/apps/skillnet-api/src/config.py
+++ b/apps/skillnet-api/src/config.py
@@ -45,6 +45,9 @@ class Settings(BaseSettings):
     ADMIN_PASSWORD: str | None = None
     ORG_NAME: str | None = None
 
+    # Agent-to-agent internal API key (auto-provisioned on startup)
+    A2A_INTERNAL_API_KEY: str | None = None
+
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
     @field_validator("SECRET_KEY")

--- a/apps/skillnet-api/src/core/bootstrap.py
+++ b/apps/skillnet-api/src/core/bootstrap.py
@@ -1,5 +1,6 @@
-"""Idempotent startup routines: migrations, default org, and admin bootstrap."""
+"""Idempotent startup routines: migrations, default org, admin, and API key bootstrap."""
 
+import hashlib
 import threading
 from pathlib import Path
 
@@ -8,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import settings
 from src.core.logging import get_logger
-from src.models import Organization, User, UserRole
+from src.models import ApiKey, Organization, User, UserRole
 
 logger = get_logger(__name__)
 
@@ -58,6 +59,44 @@ async def maybe_create_admin(session: AsyncSession) -> None:
     session.add(admin)
     await session.commit()
     logger.info("Created bootstrap admin user: %s", settings.ADMIN_EMAIL)
+
+
+async def maybe_create_a2a_api_key(
+    session: AsyncSession, org: Organization
+) -> None:
+    """Create an internal A2A API key from the env var if not already present."""
+    raw_key = settings.A2A_INTERNAL_API_KEY
+    if not raw_key:
+        return
+
+    key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
+
+    existing = await session.execute(
+        select(ApiKey).where(ApiKey.key_hash == key_hash)
+    )
+    if existing.scalar_one_or_none() is not None:
+        return
+
+    # We need a user to attribute the key to. Use the first admin.
+    admin_result = await session.execute(
+        select(User).where(User.org_id == org.id, User.role == UserRole.ADMIN).limit(1)
+    )
+    admin = admin_result.scalar_one_or_none()
+    if admin is None:
+        logger.warning("Cannot create A2A API key: no admin user found")
+        return
+
+    api_key = ApiKey(
+        org_id=org.id,
+        created_by=admin.id,
+        name="A2A Internal",
+        key_hash=key_hash,
+        scopes=["skills:read", "skills:write", "users:read"],
+        is_active=True,
+    )
+    session.add(api_key)
+    await session.commit()
+    logger.info("Created A2A internal API key for org %s", org.name)
 
 
 def run_migrations() -> None:

--- a/apps/skillnet-api/src/main.py
+++ b/apps/skillnet-api/src/main.py
@@ -9,7 +9,12 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from src.config import settings
-from src.core.bootstrap import ensure_organization, maybe_create_admin, run_migrations
+from src.core.bootstrap import (
+    ensure_organization,
+    maybe_create_a2a_api_key,
+    maybe_create_admin,
+    run_migrations,
+)
 from src.core.exceptions import AppError
 from src.core.logging import configure_logging, get_logger
 from src.deps.db import async_session_factory, engine
@@ -27,6 +32,7 @@ from src.routes import (
     stats,
     users,
 )
+from src.routes.ext import skills as ext_skills
 
 configure_logging(settings.LOG_LEVEL)
 logger = get_logger(__name__)
@@ -43,8 +49,9 @@ async def lifespan(app: FastAPI):
 
     try:
         async with async_session_factory() as session:
-            await ensure_organization(session)
+            org = await ensure_organization(session)
             await maybe_create_admin(session)
+            await maybe_create_a2a_api_key(session, org)
     except Exception as exc:  # noqa: BLE001
         logger.error("Bootstrap (org/admin) failed: %s", exc)
 
@@ -112,6 +119,10 @@ def create_app() -> FastAPI:
     app.include_router(chat.router, prefix=prefix, tags=["Chat"])
     app.include_router(stats.router, prefix=prefix)
     app.include_router(settings_routes.router, prefix=prefix)
+
+    ext_prefix = "/ext/v1"
+    app.include_router(ext_skills.router, prefix=ext_prefix)
+    app.include_router(ext_skills.user_router, prefix=ext_prefix)
 
     return app
 

--- a/apps/skillnet-api/src/models/__init__.py
+++ b/apps/skillnet-api/src/models/__init__.py
@@ -1,6 +1,7 @@
 """ORM models. Importing this package registers every table on Base.metadata."""
 
 from src.models.access_token import AccessToken
+from src.models.api_key import ApiKey
 from src.models.base import Base, TimestampMixin, UUIDMixin
 from src.models.chat_message import ChatMessage
 from src.models.chat_session import ChatSession
@@ -19,13 +20,17 @@ from src.models.lesson import Lesson
 from src.models.lesson_progress import LessonProgress
 from src.models.module import Module
 from src.models.organization import Organization
+from src.models.skill import Skill
+from src.models.skill_category import SkillCategory
 from src.models.user import LearningProfile, User, UserRole
+from src.models.user_skill import SkillLevel, UserSkill
 
 __all__ = [
     "Base",
     "UUIDMixin",
     "TimestampMixin",
     "AccessToken",
+    "ApiKey",
     "Organization",
     "User",
     "UserRole",
@@ -46,6 +51,10 @@ __all__ = [
     "GenerationJob",
     "GenerationOutput",
     "GenerationStep",
+    "Skill",
+    "SkillCategory",
+    "SkillLevel",
+    "UserSkill",
     "ChatSession",
     "ChatMessage",
 ]

--- a/apps/skillnet-api/src/models/api_key.py
+++ b/apps/skillnet-api/src/models/api_key.py
@@ -1,0 +1,27 @@
+"""API key model for external integrations."""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, ForeignKey, String, text
+from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.models.base import Base, UUIDMixin
+
+
+class ApiKey(UUIDMixin, Base):
+    __tablename__ = "api_keys"
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("organizations.id"), nullable=False
+    )
+    created_by: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    key_hash: Mapped[str] = mapped_column(String, nullable=False)
+    scopes: Mapped[list[str]] = mapped_column(ARRAY(String), nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    last_used_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    created_at: Mapped[datetime] = mapped_column(server_default=text("now()"))

--- a/apps/skillnet-api/src/models/skill.py
+++ b/apps/skillnet-api/src/models/skill.py
@@ -1,0 +1,28 @@
+"""Skill model."""
+
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base, UUIDMixin, TimestampMixin
+
+if TYPE_CHECKING:
+    from src.models.skill_category import SkillCategory
+
+
+class Skill(UUIDMixin, TimestampMixin, Base):
+    __tablename__ = "skills"
+    __table_args__ = (UniqueConstraint("org_id", "name", name="uq_skills_org_name"),)
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("organizations.id"), nullable=False
+    )
+    category_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("skill_categories.id"), nullable=True
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    category: Mapped["SkillCategory | None"] = relationship(back_populates="skills")

--- a/apps/skillnet-api/src/models/skill_category.py
+++ b/apps/skillnet-api/src/models/skill_category.py
@@ -1,0 +1,21 @@
+"""Skill category model."""
+
+import uuid
+
+from sqlalchemy import ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base, UUIDMixin, TimestampMixin
+
+
+class SkillCategory(UUIDMixin, TimestampMixin, Base):
+    __tablename__ = "skill_categories"
+    __table_args__ = (UniqueConstraint("org_id", "name", name="uq_skill_categories_org_name"),)
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("organizations.id"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    position: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    skills: Mapped[list["Skill"]] = relationship(back_populates="category")

--- a/apps/skillnet-api/src/models/user_skill.py
+++ b/apps/skillnet-api/src/models/user_skill.py
@@ -1,0 +1,47 @@
+"""User-skill association with proficiency level."""
+
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Enum as SAEnum, ForeignKey, String, UniqueConstraint, text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base, UUIDMixin
+from src.models.user import User
+from src.models.skill import Skill
+
+
+class SkillLevel(str, enum.Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class UserSkill(UUIDMixin, Base):
+    __tablename__ = "user_skills"
+    __table_args__ = (UniqueConstraint("user_id", "skill_id", name="uq_user_skills_user_skill"),)
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    skill_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("skills.id"), nullable=False
+    )
+    level: Mapped[SkillLevel] = mapped_column(
+        SAEnum(
+            SkillLevel,
+            name="skill_level",
+            values_callable=lambda e: [m.value for m in e],
+        ),
+        nullable=False,
+        default=SkillLevel.LOW,
+    )
+    source: Mapped[str] = mapped_column(String, nullable=False, default="checkpoint")
+    last_assessed_at: Mapped[datetime] = mapped_column(server_default=text("now()"))
+    updated_at: Mapped[datetime] = mapped_column(
+        server_default=text("now()"), onupdate=text("now()")
+    )
+
+    user: Mapped["User"] = relationship()
+    skill: Mapped["Skill"] = relationship()

--- a/apps/skillnet-api/src/repositories/api_key_repo.py
+++ b/apps/skillnet-api/src/repositories/api_key_repo.py
@@ -1,0 +1,29 @@
+"""API key data access."""
+
+import uuid
+from collections.abc import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.api_key import ApiKey
+from src.repositories.base import BaseRepository
+
+
+class ApiKeyRepository(BaseRepository[ApiKey]):
+    def __init__(self, session: AsyncSession) -> None:
+        super().__init__(session, ApiKey)
+
+    async def get_by_hash(self, key_hash: str) -> ApiKey | None:
+        stmt = select(ApiKey).where(ApiKey.key_hash == key_hash)
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def list_by_org(self, org_id: uuid.UUID) -> Sequence[ApiKey]:
+        stmt = (
+            select(ApiKey)
+            .where(ApiKey.org_id == org_id)
+            .order_by(ApiKey.created_at.desc())
+        )
+        result = await self.session.execute(stmt)
+        return result.scalars().all()

--- a/apps/skillnet-api/src/repositories/skill_repo.py
+++ b/apps/skillnet-api/src/repositories/skill_repo.py
@@ -1,0 +1,191 @@
+"""Skill data access: taxonomy, who-knows, gap analysis, and user-skill upsert."""
+
+import uuid
+from collections.abc import Sequence
+
+from sqlalchemy import case, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from src.models.skill import Skill
+from src.models.skill_category import SkillCategory
+from src.models.user import User
+from src.models.user_skill import SkillLevel, UserSkill
+from src.repositories.base import BaseRepository
+
+# Ordering map for level comparisons.
+_LEVEL_ORDER = {SkillLevel.LOW: 0, SkillLevel.MEDIUM: 1, SkillLevel.HIGH: 2}
+
+
+class SkillRepository(BaseRepository[Skill]):
+    def __init__(self, session: AsyncSession) -> None:
+        super().__init__(session, Skill)
+
+    # ------------------------------------------------------------------
+    # Taxonomy
+    # ------------------------------------------------------------------
+
+    async def list_skills(self, org_id: uuid.UUID) -> Sequence[SkillCategory]:
+        """Return all categories (with their skills) for an org.
+
+        Skills without a category are collected under a virtual *None* category
+        entry; callers must handle that.
+        """
+        stmt = (
+            select(SkillCategory)
+            .where(SkillCategory.org_id == org_id)
+            .options(selectinload(SkillCategory.skills))
+            .order_by(SkillCategory.position)
+        )
+        result = await self.session.execute(stmt)
+        categories = list(result.scalars().all())
+
+        # Also fetch uncategorized skills.
+        uncategorized_stmt = (
+            select(Skill)
+            .where(Skill.org_id == org_id, Skill.category_id.is_(None))
+            .order_by(Skill.name)
+        )
+        uncategorized = (await self.session.execute(uncategorized_stmt)).scalars().all()
+
+        # Return categories; the caller can inspect uncategorized separately.
+        # We attach uncategorized skills as a synthetic category with id=None.
+        if uncategorized:
+            synthetic = SkillCategory(
+                org_id=org_id, name="Uncategorized", position=-1
+            )
+            # Bypass the ORM relationship setter: just set the list directly.
+            synthetic.skills = list(uncategorized)  # type: ignore[assignment]
+            categories.insert(0, synthetic)
+
+        return categories
+
+    async def get_by_name(self, org_id: uuid.UUID, name: str) -> Skill | None:
+        stmt = select(Skill).where(Skill.org_id == org_id, Skill.name == name)
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    # ------------------------------------------------------------------
+    # Who-knows
+    # ------------------------------------------------------------------
+
+    async def who_knows(
+        self,
+        org_id: uuid.UUID,
+        skill_name: str,
+        min_level: SkillLevel | None = None,
+    ) -> list[tuple[User, SkillLevel]]:
+        """Return users who have *skill_name*, optionally filtered by min level."""
+        level_case = case(
+            (UserSkill.level == SkillLevel.LOW, 0),
+            (UserSkill.level == SkillLevel.MEDIUM, 1),
+            (UserSkill.level == SkillLevel.HIGH, 2),
+        )
+
+        stmt = (
+            select(User, UserSkill.level)
+            .join(UserSkill, UserSkill.user_id == User.id)
+            .join(Skill, Skill.id == UserSkill.skill_id)
+            .where(Skill.org_id == org_id, Skill.name == skill_name)
+        )
+
+        if min_level is not None:
+            min_ord = _LEVEL_ORDER[min_level]
+            stmt = stmt.where(level_case >= min_ord)
+
+        stmt = stmt.order_by(level_case.desc(), User.full_name)
+
+        result = await self.session.execute(stmt)
+        return list(result.tuples().all())
+
+    # ------------------------------------------------------------------
+    # Gap analysis
+    # ------------------------------------------------------------------
+
+    async def get_gaps(
+        self, org_id: uuid.UUID
+    ) -> list[dict]:
+        """For every skill in the org, count users at each level.
+
+        Returns a list of dicts:
+            {"skill_name": str, "total_users": int,
+             "low": int, "medium": int, "high": int}
+        """
+        stmt = (
+            select(
+                Skill.name.label("skill_name"),
+                func.count(UserSkill.id).label("total_users"),
+                func.count()
+                .filter(UserSkill.level == SkillLevel.LOW)
+                .label("low"),
+                func.count()
+                .filter(UserSkill.level == SkillLevel.MEDIUM)
+                .label("medium"),
+                func.count()
+                .filter(UserSkill.level == SkillLevel.HIGH)
+                .label("high"),
+            )
+            .outerjoin(UserSkill, UserSkill.skill_id == Skill.id)
+            .where(Skill.org_id == org_id)
+            .group_by(Skill.id, Skill.name)
+            .order_by(Skill.name)
+        )
+
+        result = await self.session.execute(stmt)
+        return [
+            {
+                "skill_name": row.skill_name,
+                "total_users": row.total_users,
+                "low": row.low,
+                "medium": row.medium,
+                "high": row.high,
+            }
+            for row in result.all()
+        ]
+
+    # ------------------------------------------------------------------
+    # User skills
+    # ------------------------------------------------------------------
+
+    async def get_user_skills(
+        self, org_id: uuid.UUID, user_id: uuid.UUID
+    ) -> Sequence[UserSkill]:
+        stmt = (
+            select(UserSkill)
+            .join(Skill, Skill.id == UserSkill.skill_id)
+            .where(Skill.org_id == org_id, UserSkill.user_id == user_id)
+            .options(selectinload(UserSkill.skill))
+            .order_by(Skill.name)
+        )
+        result = await self.session.execute(stmt)
+        return result.scalars().all()
+
+    async def upsert_user_skill(
+        self,
+        user_id: uuid.UUID,
+        skill_id: uuid.UUID,
+        level: SkillLevel,
+        source: str,
+    ) -> UserSkill:
+        """Insert or update a user-skill association."""
+        stmt = select(UserSkill).where(
+            UserSkill.user_id == user_id, UserSkill.skill_id == skill_id
+        )
+        result = await self.session.execute(stmt)
+        existing = result.scalar_one_or_none()
+
+        if existing is not None:
+            existing.level = level
+            existing.source = source
+            await self.session.flush()
+            return existing
+
+        user_skill = UserSkill(
+            user_id=user_id,
+            skill_id=skill_id,
+            level=level,
+            source=source,
+        )
+        self.session.add(user_skill)
+        await self.session.flush()
+        return user_skill

--- a/apps/skillnet-api/src/routes/ext/auth.py
+++ b/apps/skillnet-api/src/routes/ext/auth.py
@@ -1,0 +1,33 @@
+"""API key authentication for external (machine-to-machine) routes."""
+
+import hashlib
+from datetime import datetime, timezone
+from typing import Annotated
+
+from fastapi import Depends, Header
+
+from src.core.exceptions import ForbiddenError
+from src.deps.db import DBSession
+from src.models.api_key import ApiKey
+from src.repositories.api_key_repo import ApiKeyRepository
+
+
+async def _get_api_key(
+    db: DBSession,
+    authorization: str = Header(...),
+) -> ApiKey:
+    if not authorization.startswith("Bearer "):
+        raise ForbiddenError("Invalid authorization header")
+    token = authorization.removeprefix("Bearer ").strip()
+    key_hash = hashlib.sha256(token.encode()).hexdigest()
+    repo = ApiKeyRepository(db)
+    api_key = await repo.get_by_hash(key_hash)
+    if api_key is None or not api_key.is_active:
+        raise ForbiddenError("Invalid or inactive API key")
+    # Update last_used_at
+    api_key.last_used_at = datetime.now(timezone.utc)
+    await db.flush()
+    return api_key
+
+
+ExtApiKey = Annotated[ApiKey, Depends(_get_api_key)]

--- a/apps/skillnet-api/src/routes/ext/skills.py
+++ b/apps/skillnet-api/src/routes/ext/skills.py
@@ -1,0 +1,94 @@
+"""External skills endpoints — authenticated via API key."""
+
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, Query
+
+from src.deps.db import DBSession
+from src.repositories.skill_repo import SkillRepository
+from src.routes.ext.auth import ExtApiKey
+from src.schemas.skill import (
+    GapReport,
+    GapReportEntry,
+    SkillCategoryRead,
+    UserSkillRead,
+    VerifySkillRequest,
+    VerifySkillResponse,
+    WhoKnowsEntry,
+    WhoKnowsResponse,
+)
+from src.services.skill_service import SkillService
+
+router = APIRouter(prefix="/skills", tags=["Skills (external)"])
+
+# Separate router for user-scoped paths that don't share the /skills prefix.
+user_router = APIRouter(prefix="/users", tags=["Skills (external)"])
+
+
+def _service(db: DBSession) -> SkillService:
+    return SkillService(SkillRepository(db))
+
+
+@router.get("", response_model=list[SkillCategoryRead])
+async def list_skills(
+    api_key: ExtApiKey,
+    db: DBSession,
+) -> list[SkillCategoryRead]:
+    service = _service(db)
+    categories = await service.list_skills(api_key.org_id)
+    return [SkillCategoryRead(**c) for c in categories]
+
+
+@router.get("/who-knows", response_model=WhoKnowsResponse)
+async def who_knows(
+    api_key: ExtApiKey,
+    db: DBSession,
+    skill: Annotated[str, Query(description="Skill name to search for")],
+    min_level: Annotated[str | None, Query(description="Minimum level: low, medium, high")] = None,
+) -> WhoKnowsResponse:
+    service = _service(db)
+    employees = await service.who_knows(api_key.org_id, skill, min_level)
+    return WhoKnowsResponse(
+        skill=skill,
+        employees=[WhoKnowsEntry(**e) for e in employees],
+    )
+
+
+@router.get("/gaps", response_model=GapReport)
+async def get_gaps(
+    api_key: ExtApiKey,
+    db: DBSession,
+) -> GapReport:
+    service = _service(db)
+    gaps = await service.get_gap(api_key.org_id)
+    return GapReport(gaps=[GapReportEntry(**g) for g in gaps])
+
+
+@router.post("/verify", response_model=VerifySkillResponse, status_code=200)
+async def verify_skill(
+    api_key: ExtApiKey,
+    db: DBSession,
+    body: VerifySkillRequest,
+) -> VerifySkillResponse:
+    service = _service(db)
+    result = await service.verify_skill(
+        org_id=api_key.org_id,
+        user_id=body.user_id,
+        skill_name=body.skill_name,
+        level=body.level,
+        source=body.source,
+    )
+    await db.commit()
+    return VerifySkillResponse(**result)
+
+
+@user_router.get("/{user_id}/skills", response_model=list[UserSkillRead])
+async def get_user_skills(
+    api_key: ExtApiKey,
+    db: DBSession,
+    user_id: uuid.UUID,
+) -> list[UserSkillRead]:
+    service = _service(db)
+    skills = await service.get_user_skills(api_key.org_id, user_id)
+    return [UserSkillRead(**s) for s in skills]

--- a/apps/skillnet-api/src/schemas/skill.py
+++ b/apps/skillnet-api/src/schemas/skill.py
@@ -1,0 +1,100 @@
+"""Skill schemas: taxonomy, who-knows, gaps, and verification."""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+# ------------------------------------------------------------------
+# Read schemas
+# ------------------------------------------------------------------
+
+
+class SkillRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    name: str
+    description: str | None = None
+
+
+class SkillCategoryRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID | None = None
+    name: str
+    position: int
+    skills: list[SkillRead] = []
+
+
+class UserSkillRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    skill_id: uuid.UUID
+    skill_name: str
+    level: str
+    source: str
+    last_assessed_at: datetime | None = None
+
+
+# ------------------------------------------------------------------
+# Create schemas
+# ------------------------------------------------------------------
+
+
+class SkillCategoryCreate(BaseModel):
+    name: str
+    position: int = 0
+
+
+class SkillCreate(BaseModel):
+    name: str
+    description: str | None = None
+    category_id: uuid.UUID | None = None
+
+
+# ------------------------------------------------------------------
+# Response schemas
+# ------------------------------------------------------------------
+
+
+class WhoKnowsEntry(BaseModel):
+    user_id: uuid.UUID
+    full_name: str
+    email: str
+    level: str
+
+
+class WhoKnowsResponse(BaseModel):
+    skill: str
+    employees: list[WhoKnowsEntry]
+
+
+class GapReportEntry(BaseModel):
+    skill_name: str
+    total_users: int
+    low: int
+    medium: int
+    high: int
+
+
+class GapReport(BaseModel):
+    gaps: list[GapReportEntry]
+
+
+class VerifySkillRequest(BaseModel):
+    user_id: uuid.UUID
+    skill_name: str
+    level: str
+    source: str = "checkpoint"
+
+
+class VerifySkillResponse(BaseModel):
+    user_skill_id: uuid.UUID
+    user_id: uuid.UUID
+    skill_id: uuid.UUID
+    skill_name: str
+    level: str
+    source: str

--- a/apps/skillnet-api/src/services/skill_service.py
+++ b/apps/skillnet-api/src/services/skill_service.py
@@ -1,0 +1,114 @@
+"""Skill business logic: taxonomy, who-knows, gap analysis, and verification."""
+
+import uuid
+
+from src.core.exceptions import NotFoundError, ValidationError
+from src.models.user_skill import SkillLevel
+from src.repositories.skill_repo import SkillRepository
+
+
+def _to_level(value: str) -> SkillLevel:
+    try:
+        return SkillLevel(value)
+    except ValueError as exc:
+        raise ValidationError(f"Invalid skill level: {value}", field="level") from exc
+
+
+class SkillService:
+    def __init__(self, repo: SkillRepository) -> None:
+        self.repo = repo
+
+    async def list_skills(self, org_id: uuid.UUID) -> list[dict]:
+        """Return the full skill taxonomy grouped by category."""
+        categories = await self.repo.list_skills(org_id)
+        result = []
+        for cat in categories:
+            result.append(
+                {
+                    "id": getattr(cat, "id", None),
+                    "name": cat.name,
+                    "position": cat.position,
+                    "skills": [
+                        {
+                            "id": s.id,
+                            "name": s.name,
+                            "description": s.description,
+                        }
+                        for s in cat.skills
+                    ],
+                }
+            )
+        return result
+
+    async def who_knows(
+        self,
+        org_id: uuid.UUID,
+        skill_name: str,
+        min_level: str | None = None,
+    ) -> list[dict]:
+        """Find employees who possess a given skill."""
+        level_enum = _to_level(min_level) if min_level else None
+        rows = await self.repo.who_knows(org_id, skill_name, level_enum)
+        return [
+            {
+                "user_id": user.id,
+                "full_name": user.full_name,
+                "email": user.email,
+                "level": level.value,
+            }
+            for user, level in rows
+        ]
+
+    async def get_gap(self, org_id: uuid.UUID) -> list[dict]:
+        """Return gap analysis for every skill in the org."""
+        return await self.repo.get_gaps(org_id)
+
+    async def verify_skill(
+        self,
+        org_id: uuid.UUID,
+        user_id: uuid.UUID,
+        skill_name: str,
+        level: str,
+        source: str,
+    ) -> dict:
+        """Create or update a user's proficiency for a skill.
+
+        If the skill does not exist yet, it is created automatically.
+        """
+        level_enum = _to_level(level)
+
+        skill = await self.repo.get_by_name(org_id, skill_name)
+        if skill is None:
+            skill = await self.repo.create(org_id=org_id, name=skill_name)
+
+        user_skill = await self.repo.upsert_user_skill(
+            user_id=user_id,
+            skill_id=skill.id,
+            level=level_enum,
+            source=source,
+        )
+        return {
+            "user_skill_id": user_skill.id,
+            "user_id": user_skill.user_id,
+            "skill_id": user_skill.skill_id,
+            "skill_name": skill.name,
+            "level": user_skill.level.value,
+            "source": user_skill.source,
+        }
+
+    async def get_user_skills(
+        self, org_id: uuid.UUID, user_id: uuid.UUID
+    ) -> list[dict]:
+        """Return all skills for a given user."""
+        user_skills = await self.repo.get_user_skills(org_id, user_id)
+        return [
+            {
+                "id": us.id,
+                "skill_id": us.skill_id,
+                "skill_name": us.skill.name,
+                "level": us.level.value,
+                "source": us.source,
+                "last_assessed_at": us.last_assessed_at,
+            }
+            for us in user_skills
+        ]

--- a/apps/skillnet-api/tests/test_skill_service.py
+++ b/apps/skillnet-api/tests/test_skill_service.py
@@ -1,0 +1,126 @@
+"""Unit tests for SkillService (pure logic, mocked repo)."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.models.user_skill import SkillLevel
+
+
+def _make_user(name: str, org_id: uuid.UUID) -> MagicMock:
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.org_id = org_id
+    user.full_name = name
+    user.email = f"{name.lower().replace(' ', '.')}@test.com"
+    return user
+
+
+def _make_skill(name: str, org_id: uuid.UUID, category_name: str = "General") -> MagicMock:
+    skill = MagicMock()
+    skill.id = uuid.uuid4()
+    skill.org_id = org_id
+    skill.name = name
+    skill.description = None
+    category = MagicMock()
+    category.name = category_name
+    skill.category = category
+    return skill
+
+
+def _make_user_skill(user, skill, level: SkillLevel) -> MagicMock:
+    us = MagicMock()
+    us.user_id = user.id
+    us.skill_id = skill.id
+    us.level = level
+    us.source = "manual"
+    us.user = user
+    us.skill = skill
+    return us
+
+
+@pytest.fixture
+def org_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def repo():
+    repo = AsyncMock()
+    return repo
+
+
+@pytest.fixture
+def service(repo):
+    from src.services.skill_service import SkillService
+    return SkillService(repo)
+
+
+@pytest.mark.asyncio
+async def test_who_knows_returns_matching_users(service, repo, org_id):
+    """who_knows should return users with the skill."""
+    user1 = _make_user("Maria", org_id)
+    user2 = _make_user("Juan", org_id)
+    skill = _make_skill("Python", org_id)
+
+    repo.who_knows.return_value = [
+        (user1, SkillLevel.HIGH),
+        (user2, SkillLevel.MEDIUM),
+    ]
+
+    result = await service.who_knows(org_id, "Python")
+
+    repo.who_knows.assert_awaited_once()
+    assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_who_knows_empty(service, repo, org_id):
+    """who_knows should return empty list when no one has the skill."""
+    repo.who_knows.return_value = []
+
+    result = await service.who_knows(org_id, "Nonexistent")
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_list_skills(service, repo, org_id):
+    """list_skills should return skills from repo."""
+    skill1 = _make_skill("Python", org_id, "Tech")
+    skill2 = _make_skill("SQL", org_id, "Tech")
+    repo.list_skills.return_value = [skill1, skill2]
+
+    result = await service.list_skills(org_id)
+
+    repo.list_skills.assert_awaited_once_with(org_id)
+    assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_user_skills(service, repo, org_id):
+    """get_user_skills should return all skills for a user."""
+    user = _make_user("Maria", org_id)
+    skill = _make_skill("Python", org_id)
+    us = _make_user_skill(user, skill, SkillLevel.HIGH)
+
+    repo.get_user_skills.return_value = [us]
+
+    result = await service.get_user_skills(org_id, user.id)
+
+    repo.get_user_skills.assert_awaited_once()
+    assert len(result) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_gap(service, repo, org_id):
+    """get_gap should return gap analysis."""
+    repo.get_gaps.return_value = [
+        {"skill_name": "Python", "total": 10, "high": 1, "medium": 2, "low": 3, "none": 4},
+    ]
+
+    result = await service.get_gap(org_id)
+
+    repo.get_gaps.assert_awaited_once()
+    assert len(result) >= 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       ADMIN_EMAIL: ${ADMIN_EMAIL:-}
       ADMIN_PASSWORD: ${ADMIN_PASSWORD:-}
       ORG_NAME: ${ORG_NAME:-SkillNet}
+      A2A_INTERNAL_API_KEY: ${A2A_INTERNAL_API_KEY:-}
     volumes:
       - uploads:/data/uploads
     depends_on:
@@ -77,6 +78,28 @@ services:
       timeout: 5s
       retries: 10
       start_period: 30s
+
+  # ── A2A Agent Server (optional) ─────────────────────────────
+  a2a:
+    build:
+      context: .
+      dockerfile: docker/a2a.Dockerfile
+    restart: unless-stopped
+    profiles: [a2a]
+    ports:
+      - "${A2A_PORT:-5000}:5000"
+    environment:
+      API_URL: http://api:8000
+      SKILLNET_API_KEY: ${A2A_INTERNAL_API_KEY:-}
+      LLM_BASE_URL: ${LLM_BASE_URL:-}
+      LLM_API_KEY: ${LLM_API_KEY:-}
+      LLM_MODEL: ${A2A_LLM_MODEL:-gpt-4o-mini}
+      A2A_PORT: "5000"
+      A2A_AUTH_KEY: ${A2A_AUTH_KEY:-}
+      A2A_AGENT_URL: ${A2A_AGENT_URL:-http://localhost:5000}
+    depends_on:
+      api:
+        condition: service_healthy
 
   # ── Frontend (nginx + React SPA) ───────────────────────────
   web:

--- a/docker/a2a.Dockerfile
+++ b/docker/a2a.Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1
+# SkillNet A2A Server — multi-stage build with uv. Build context is the repo root.
+
+# ── Stage 1: Dependencies + project install ──────────────────────────
+FROM python:3.12-slim AS builder
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PROJECT_ENVIRONMENT=/app/.venv
+
+WORKDIR /app
+
+# Dependency layer first for caching: only the manifest.
+COPY apps/skillnet-a2a/pyproject.toml ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-install-project || uv pip install -r pyproject.toml
+
+# Application source, then install the project itself.
+COPY apps/skillnet-a2a/ ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev || true
+
+# ── Stage 2: Runtime ─────────────────────────────────────────────────
+FROM python:3.12-slim AS runtime
+
+RUN groupadd -r skillnet && \
+    useradd -r -g skillnet -d /app -s /sbin/nologin skillnet
+
+WORKDIR /app
+
+COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/src /app/src
+COPY --from=builder /app/pyproject.toml /app/pyproject.toml
+
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+RUN chown -R skillnet:skillnet /app
+
+USER skillnet
+
+EXPOSE 5000
+
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "5000", "--workers", "1"]

--- a/scripts/test_a2a.py
+++ b/scripts/test_a2a.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Demo script: send natural-language tasks to the SkillNet A2A server.
+
+Usage:
+    python scripts/test_a2a.py [--url http://localhost:5000] [--auth-key KEY]
+
+Requires: httpx (pip install httpx)
+"""
+
+import argparse
+import asyncio
+import json
+import sys
+
+import httpx
+
+
+async def send_message(url: str, text: str, auth_key: str = "") -> dict:
+    """Send a message to the A2A server and return the response."""
+    headers = {}
+    if auth_key:
+        headers["Authorization"] = f"Bearer {auth_key}"
+
+    payload = {
+        "jsonrpc": "2.0",
+        "method": "message/send",
+        "params": {
+            "message": {
+                "role": "user",
+                "parts": [{"type": "text", "text": text}],
+            },
+        },
+        "id": 1,
+    }
+
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        resp = await client.post(url, json=payload, headers=headers)
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def get_agent_card(url: str) -> dict:
+    """Fetch the AgentCard."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{url}/.well-known/agent.json")
+        resp.raise_for_status()
+        return resp.json()
+
+
+def extract_text(response: dict) -> str:
+    """Extract the text response from an A2A result."""
+    result = response.get("result", {})
+    artifacts = result.get("artifacts", [])
+    if not artifacts:
+        error = response.get("error", {})
+        return f"ERROR: {error.get('message', 'Unknown error')}"
+    parts = artifacts[0].get("parts", [])
+    return parts[0].get("text", "") if parts else "(empty response)"
+
+
+TEST_MESSAGES = [
+    "What skills do we track in our organization?",
+    "Who knows Python in the team?",
+    "What are our biggest skill gaps?",
+    "What skills does the first employee have?",
+]
+
+
+async def main(url: str, auth_key: str) -> None:
+    print(f"\n{'='*60}")
+    print(f"  SkillNet A2A Demo — {url}")
+    print(f"{'='*60}\n")
+
+    # 1. Fetch AgentCard
+    print("[1] Fetching AgentCard...")
+    try:
+        card = await get_agent_card(url)
+        print(f"    Agent: {card.get('name', '?')}")
+        print(f"    Description: {card.get('description', '?')}")
+        skills = card.get("skills", [])
+        print(f"    Skills: {', '.join(s.get('id', '?') for s in skills)}")
+        print()
+    except Exception as e:
+        print(f"    FAILED: {e}\n")
+        return
+
+    # 2. Send test messages
+    for i, msg in enumerate(TEST_MESSAGES, start=2):
+        print(f"[{i}] User: {msg}")
+        try:
+            response = await send_message(url, msg, auth_key)
+            answer = extract_text(response)
+            print(f"    Agent: {answer[:500]}")
+        except Exception as e:
+            print(f"    FAILED: {e}")
+        print()
+
+    print(f"{'='*60}")
+    print("  Demo complete.")
+    print(f"{'='*60}\n")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Test the SkillNet A2A server")
+    parser.add_argument("--url", default="http://localhost:5000", help="A2A server URL")
+    parser.add_argument("--auth-key", default="", help="Bearer auth key")
+    args = parser.parse_args()
+
+    asyncio.run(main(args.url, args.auth_key))


### PR DESCRIPTION
## Summary

- **Skills subsystem**: SkillCategory, Skill, UserSkill models + Alembic migration (4 tables). SkillRepository with who_knows (CASE-based level ordering), gap analysis, upsert. SkillService with business logic.
- **External API** (`/ext/v1/`): API key auth (SHA-256), 5 endpoints for skills (who-knows, gaps, verify, list, user profile). Auto-bootstrap of A2A internal API key from env var.
- **A2A agent server** (`apps/skillnet-a2a/`): Standalone Starlette app implementing A2A protocol (JSON-RPC 2.0). LLM orchestrator with tool-calling loop (litellm), 5 tools mapping to external API. AgentCard at `/.well-known/agent.json`.
- **Docker**: Multi-stage Dockerfile, Compose profile (`--profile a2a`), port 5000.
- **Tests + demo**: Unit tests for SkillService and orchestrator. Demo script (`scripts/test_a2a.py`).

## Architecture

```
External Agent ──A2A──→ Orchestrator (LLM) ──→ /ext/v1/ ──→ SkillService ──→ PostgreSQL
```

## How to test

```bash
# Launch with A2A enabled
docker compose --profile a2a up -d

# Check AgentCard
curl http://localhost:5000/.well-known/agent.json

# Run demo
python scripts/test_a2a.py
```

## Test plan

- [ ] Alembic migration runs without errors
- [ ] External API endpoints respond with API key auth
- [ ] AgentCard served at /.well-known/agent.json
- [ ] A2A server processes natural language queries
- [ ] Unit tests pass: `pytest apps/skillnet-api/tests/test_skill_service.py`
- [ ] Unit tests pass: `pytest apps/skillnet-a2a/tests/test_orchestrator.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)