### PR TITLE
feat: assign skills to users on course completion

### DIFF
--- a/apps/skillnet-api/alembic/versions/0004_add_course_skills.py
+++ b/apps/skillnet-api/alembic/versions/0004_add_course_skills.py
@@ -1,0 +1,37 @@
+"""add course_skills join table
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-07-21
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0004"
+down_revision: str | None = "0003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "course_skills",
+        sa.Column("id", sa.Uuid(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("course_id", sa.Uuid(), nullable=False),
+        sa.Column("skill_id", sa.Uuid(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["course_id"], ["courses.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["skill_id"], ["skills.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("course_id", "skill_id", name="uq_course_skills_course_skill"),
+    )
+    op.create_index("idx_course_skills_course", "course_skills", ["course_id"])
+    op.create_index("idx_course_skills_skill", "course_skills", ["skill_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_course_skills_skill", table_name="course_skills")
+    op.drop_index("idx_course_skills_course", table_name="course_skills")
+    op.drop_table("course_skills")

--- a/apps/skillnet-api/src/agents/content/nodes.py
+++ b/apps/skillnet-api/src/agents/content/nodes.py
@@ -38,6 +38,7 @@ from src.llm.prompts import (
 )
 from src.models import (
     Course,
+    CourseSkill,
     Document,
     DocumentChunk,
     Exercise,
@@ -469,8 +470,8 @@ async def refine_content(state: GenerationState) -> dict:
 # --------------------------------------------------------------------------- #
 async def _auto_create_skills(
     db: Any, org_id: uuid.UUID, state: GenerationState
-) -> None:
-    """Create Skill records from extracted themes if they don't already exist.
+) -> list[uuid.UUID]:
+    """Create Skill records from extracted themes and return their IDs.
 
     Maps each theme's name to a skill. Themes are the concepts the LLM
     identified in the source document — they naturally correspond to the
@@ -478,9 +479,10 @@ async def _auto_create_skills(
     """
     themes = state.get("extracted_themes") or []
     if not themes:
-        return
+        return []
 
     repo = SkillRepository(db)
+    skill_ids: list[uuid.UUID] = []
 
     for theme in themes:
         name = theme.get("name") or theme.get("title") or ""
@@ -490,13 +492,17 @@ async def _auto_create_skills(
 
         existing = await repo.get_by_name(org_id, name)
         if existing is not None:
+            skill_ids.append(existing.id)
             continue
 
         description = theme.get("description") or theme.get("summary") or ""
-        db.add(Skill(org_id=org_id, name=name, description=description[:500]))
+        skill = Skill(org_id=org_id, name=name, description=description[:500])
+        db.add(skill)
+        await db.flush()
+        skill_ids.append(skill.id)
 
-    await db.flush()
     logger.info("Auto-created skills from %d themes for org %s", len(themes), org_id)
+    return skill_ids
 
 
 # --------------------------------------------------------------------------- #
@@ -536,8 +542,11 @@ async def publish(state: GenerationState) -> dict:
             course.status = "draft"
             await db.flush()
 
-        # Auto-create skills from themes extracted earlier in the pipeline.
-        await _auto_create_skills(db, org_id, state)
+        # Auto-create skills from themes and link them to the course.
+        skill_ids = await _auto_create_skills(db, org_id, state)
+        for skill_id in skill_ids:
+            db.add(CourseSkill(course_id=course.id, skill_id=skill_id))
+        await db.flush()
 
         for mod_position, gen_module in enumerate(
             state.get("generated_modules", []), start=1

--- a/apps/skillnet-api/src/models/__init__.py
+++ b/apps/skillnet-api/src/models/__init__.py
@@ -6,6 +6,7 @@ from src.models.base import Base, TimestampMixin, UUIDMixin
 from src.models.chat_message import ChatMessage
 from src.models.chat_session import ChatSession
 from src.models.course import ContentStatus, Course
+from src.models.course_skill import CourseSkill
 from src.models.document import Document, DocumentStatus
 from src.models.document_chunk import DocumentChunk
 from src.models.enrollment import Enrollment, EnrollmentStatus
@@ -40,6 +41,7 @@ __all__ = [
     "DocumentChunk",
     "Course",
     "ContentStatus",
+    "CourseSkill",
     "Module",
     "Lesson",
     "LessonProgress",

--- a/apps/skillnet-api/src/models/course_skill.py
+++ b/apps/skillnet-api/src/models/course_skill.py
@@ -1,0 +1,22 @@
+"""Association between courses and the skills they teach."""
+
+import uuid
+
+from sqlalchemy import ForeignKey, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.models.base import Base, UUIDMixin
+
+
+class CourseSkill(UUIDMixin, Base):
+    __tablename__ = "course_skills"
+    __table_args__ = (
+        UniqueConstraint("course_id", "skill_id", name="uq_course_skills_course_skill"),
+    )
+
+    course_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("courses.id", ondelete="CASCADE"), nullable=False
+    )
+    skill_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("skills.id", ondelete="CASCADE"), nullable=False
+    )

--- a/apps/skillnet-api/src/services/enrollment_service.py
+++ b/apps/skillnet-api/src/services/enrollment_service.py
@@ -4,12 +4,19 @@ import uuid
 from collections.abc import Sequence
 from datetime import date, datetime, timezone
 
+from sqlalchemy import select
+
 from src.core.exceptions import ConflictError, ForbiddenError, NotFoundError
+from src.core.logging import get_logger
 from src.models import Enrollment, EnrollmentStatus
+from src.models.course_skill import CourseSkill
+from src.models.user_skill import SkillLevel, UserSkill
 from src.repositories.course_repo import CourseRepository
 from src.repositories.enrollment_repo import EnrollmentRepository
 from src.repositories.exercise_repo import ExerciseRepository
 from src.repositories.lesson_progress_repo import LessonProgressRepository
+
+logger = get_logger(__name__)
 
 
 class EnrollmentService:
@@ -165,7 +172,61 @@ class EnrollmentService:
         enrollment.completed_at = datetime.now(timezone.utc)
         enrollment.score = progress
         await self.enrollment_repo.session.flush()
+
+        # Assign skills linked to the course.
+        await self._assign_course_skills(enrollment.user_id, enrollment.course_id)
+
         return enrollment, progress or 0.0
+
+    async def _assign_course_skills(
+        self, user_id: uuid.UUID, course_id: uuid.UUID
+    ) -> None:
+        """Assign skills linked to the completed course to the user.
+
+        When a user completes a course, they earn all skills associated
+        with that course at 'medium' level (first completion) or keep
+        their existing level if already higher.
+        """
+        db = self.enrollment_repo.session
+
+        # Find skills linked to this course.
+        result = await db.execute(
+            select(CourseSkill.skill_id).where(CourseSkill.course_id == course_id)
+        )
+        skill_ids = [row[0] for row in result.all()]
+        if not skill_ids:
+            return
+
+        for skill_id in skill_ids:
+            # Check if user already has this skill.
+            existing = await db.execute(
+                select(UserSkill).where(
+                    UserSkill.user_id == user_id,
+                    UserSkill.skill_id == skill_id,
+                )
+            )
+            user_skill = existing.scalar_one_or_none()
+
+            if user_skill is not None:
+                # Only upgrade, never downgrade.
+                level_order = {SkillLevel.LOW: 0, SkillLevel.MEDIUM: 1, SkillLevel.HIGH: 2}
+                if level_order.get(user_skill.level, 0) < level_order[SkillLevel.MEDIUM]:
+                    user_skill.level = SkillLevel.MEDIUM
+                    user_skill.source = "course_completion"
+                    user_skill.last_assessed_at = datetime.now(timezone.utc)
+            else:
+                db.add(UserSkill(
+                    user_id=user_id,
+                    skill_id=skill_id,
+                    level=SkillLevel.MEDIUM,
+                    source="course_completion",
+                ))
+
+        await db.flush()
+        logger.info(
+            "Assigned %d skills to user %s from course %s",
+            len(skill_ids), user_id, course_id,
+        )
 
     async def delete(self, *, enrollment_id: uuid.UUID, org_id: uuid.UUID) -> None:
         enrollment = await self.get_scoped(


### PR DESCRIPTION
## Summary

Closes the skills loop — now the full cycle works:

```
1. Admin sube documento
2. Pipeline genera curso + crea skills + vincula skills al curso (course_skills)
3. Empleado toma el curso, completa ejercicios
4. Empleado marca como completado → gana skills a nivel medium
5. A2A agent puede responder "¿quién sabe X?" con datos reales
```

### Changes

- **`CourseSkill` model** + migration 0004: join table `course_skills` (course_id ↔ skill_id)
- **Pipeline `publish` node**: links auto-created skills to the generated course
- **`EnrollmentService.complete()`**: when a user completes a course, assigns all linked skills at `medium` level. Never downgrades existing higher levels.
- Source tracked as `"course_completion"` in `user_skills`

## Test plan

- [ ] Generate a course → verify `course_skills` records created
- [ ] Complete the course as employee → verify `user_skills` records created at medium
- [ ] Complete again → verify level not downgraded
- [ ] `GET /ext/v1/skills/who-knows?skill=X` returns the employee

🤖 Generated with [Claude Code](https://claude.com/claude-code)