### PR TITLE
fix: renders dejan de fallar (17% -> 0%), generative UI en los dos chats

### DIFF
--- a/apps/skillnet-api/scripts/quality_bench.py
+++ b/apps/skillnet-api/scripts/quality_bench.py
@@ -64,6 +64,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import collections
 import contextvars
 import json
 import math
@@ -106,10 +107,16 @@ from src.models import (  # noqa: E402
     NodeState,
     UiFormat,
 )
+from src.render.kit import LLM_COMPONENT_NAMES  # noqa: E402
 
 # --------------------------------------------------------------------------------------
 # Diales del propio banco
 # --------------------------------------------------------------------------------------
+
+#: Los bloques que el modelo PUEDE emitir — el denominador de la cobertura de catalogo.
+#: ``Markdown`` queda fuera a proposito: ``llm_emittable`` es falso y solo lo escribe
+#: ``fallback_seed``, asi que contarlo premiaria justo el desenlace que no queremos.
+EMITTABLE_BLOCKS: tuple[str, ...] = LLM_COMPONENT_NAMES
 
 #: El User-Agent por defecto de Python recibe **403 de Groq** (medido). Cualquier cadena
 #: identificable sirve; lo que no sirve es no poner ninguna.
@@ -1360,6 +1367,10 @@ class RunResult:
     steps: list[str]
     cache_key: str
     reason: str = ""
+    #: Tipos de bloque del spec que REALMENTE se sirvio, uno por aparicion. Es la medida
+    #: que faltaba: un render valido con tres TextContent seguidos pasa todas las demas
+    #: columnas y aun asi es la pantalla que el dueno rechazo.
+    block_types: list[str] = field(default_factory=list)
 
 
 async def run_one(
@@ -1489,7 +1500,28 @@ def _classify(
         steps=list(recorder.steps),
         cache_key=recorder.cache_key,
         reason=reason[:400],
+        block_types=_block_types(render),
     )
+
+
+def _block_types(render: NodeRender | None) -> list[str]:
+    """Los tipos de bloque del ``ui_spec`` persistido, uno por aparicion.
+
+    Se lee de la fila y no del estado del grafo a proposito: la fila lleva el spec
+    **canonico**, el que ``gate.canonicalize`` re-serializo y el unico que llega al
+    navegador. Un intento rechazado no cuenta aunque hubiera usado un Table precioso.
+    """
+    spec = getattr(render, "ui_spec", None)
+    if not isinstance(spec, dict):
+        return []
+    components = spec.get("components")
+    if not isinstance(components, list):
+        return []
+    return [
+        str(component.get("type"))
+        for component in components
+        if isinstance(component, dict) and component.get("type")
+    ]
 
 
 _INFRA_MARKERS = (
@@ -1598,11 +1630,19 @@ class Aggregate:
     tokens_out: list[int] = field(default_factory=list)
     cost: float = 0.0
     cost_known: bool = True
+    #: Cuantas veces aparecio cada tipo de bloque en los specs servidos.
+    blocks: collections.Counter[str] = field(default_factory=collections.Counter)
+    #: Tipos distintos por render, para poder decir "una pantalla usa 2,1 tipos de media"
+    #: ademas de "la tanda entera toco 3 de 9".
+    distinct_per_run: list[int] = field(default_factory=list)
 
     def add(self, run: RunResult) -> None:
         self.runs += 1
         setattr(self, run.outcome, getattr(self, run.outcome) + 1)
         self.seconds.append(run.seconds)
+        if run.block_types:
+            self.blocks.update(run.block_types)
+            self.distinct_per_run.append(len(set(run.block_types)))
         if run.tokens_in is not None:
             self.tokens_in.append(run.tokens_in)
         if run.tokens_out is not None:
@@ -1616,6 +1656,15 @@ class Aggregate:
     def graded(self) -> int:
         """Ejecuciones que dicen algo sobre la calidad (sin fallos de infraestructura)."""
         return self.first_pass + self.repaired + self.fallback
+
+    @property
+    def types_used(self) -> list[str]:
+        """Tipos emitibles que aparecieron al menos una vez, en el orden del catalogo."""
+        return [name for name in EMITTABLE_BLOCKS if self.blocks.get(name)]
+
+    @property
+    def types_unused(self) -> list[str]:
+        return [name for name in EMITTABLE_BLOCKS if not self.blocks.get(name)]
 
     def rate(self, field_name: str) -> float:
         base = self.graded
@@ -1647,6 +1696,18 @@ class Aggregate:
             "cost_usd_per_run": round(self.cost / self.runs, 6)
             if self.cost_known and self.runs
             else None,
+            # --- cobertura del catalogo (§5.3) ---------------------------------
+            "distinct_block_types": len(self.types_used),
+            "block_type_coverage_pct": round(
+                100.0 * len(self.types_used) / len(EMITTABLE_BLOCKS), 1
+            ),
+            "mean_distinct_types_per_render": round(
+                statistics.fmean(self.distinct_per_run), 2
+            )
+            if self.distinct_per_run
+            else None,
+            "block_types": dict(self.blocks.most_common()),
+            "block_types_unused": self.types_unused,
         }
 
 
@@ -1680,6 +1741,37 @@ def _num(value: Any) -> str:
     return "n/d" if value is None else f"{value:.0f}"
 
 
+def print_coverage(total: Aggregate) -> None:
+    """Que parte del catalogo se uso de verdad.
+
+    Esta seccion existe por un fallo que ninguna de las columnas de arriba veia. El nodo
+    de los catorce alergenos salio ``ready``, a la primera segun la fila, con cuatro
+    bloques validos — y era un parrafo con catorce cosas separadas por comas, porque el
+    modelo solo habia usado ``TextContent`` y ``Callout``. Un render puede ser
+    perfectamente valido y aun asi ser la pantalla equivocada, y "3 de 9" es el numero que
+    lo dice en voz alta.
+    """
+    used = total.types_used
+    print()
+    print(
+        f"Cobertura del catalogo: {len(used)} de {len(EMITTABLE_BLOCKS)} tipos emitibles "
+        f"({100.0 * len(used) / len(EMITTABLE_BLOCKS):.0f} %)"
+    )
+    if total.distinct_per_run:
+        print(
+            f"  Tipos distintos por pantalla (media): "
+            f"{statistics.fmean(total.distinct_per_run):.2f}"
+        )
+    total_blocks = sum(total.blocks.values()) or 1
+    for name in EMITTABLE_BLOCKS:
+        count = total.blocks.get(name, 0)
+        share = 100.0 * count / total_blocks
+        mark = "  " if count else "->"
+        print(f"  {mark} {name:<14} {count:>4}  {share:>5.1f} %")
+    if total.types_unused:
+        print(f"  Sin usar ni una vez: {', '.join(total.types_unused)}")
+
+
 def print_comparison(current: dict, previous: dict | None) -> None:
     if previous is None:
         print(
@@ -1701,6 +1793,8 @@ def print_comparison(current: dict, previous: dict | None) -> None:
         ("latencia p95", "p95_seconds", "s", 2, False),
         ("tokens de salida (media)", "mean_tokens_out", "", 0, False),
         ("coste por render", "cost_usd_per_run", " USD", 6, False),
+        ("tipos de bloque usados", "distinct_block_types", f"/{len(EMITTABLE_BLOCKS)}", 0, True),
+        ("tipos por pantalla (media)", "mean_distinct_types_per_render", "", 2, True),
     )
     for label, key, unit, digits, higher_is_better in rows:
         old = before.get(key)
@@ -2078,6 +2172,7 @@ async def run_bench(args: argparse.Namespace) -> int:
         total.add(run)
 
     print_table(per_encargo, total)
+    print_coverage(total)
 
     if stats.rate_limited or stats.exhausted:
         print(

--- a/apps/skillnet-api/src/agents/runtime/nodes.py
+++ b/apps/skillnet-api/src/agents/runtime/nodes.py
@@ -51,6 +51,7 @@ from src.agents.runtime.router import (
     tier_config,
     tier_llm,
 )
+from src.agents.runtime.shape import analyze_shape, focus_on_headings, refine_format
 from src.agents.runtime.state import NodeRuntimeState
 from src.core import sse
 from src.core.logging import get_logger
@@ -161,7 +162,14 @@ async def load_source_context(db: Any, node: CourseNode, org_id: uuid.UUID) -> s
         return ""
 
     if estimate_pages(document) <= FULL_TEXT_PAGE_THRESHOLD and document.full_text:
-        return clip_source(document.full_text)
+        # Scoped to the node's own headings, exactly like the chunked branch below.
+        # The asymmetry was invisible and expensive: a document of <= 5 pages went in
+        # WHOLE, so all three nodes of the seeded ``Alergenos`` course were handed the
+        # same text and the node about cross-contamination was asked to teach from the
+        # fourteen allergens as well. It also costs tokens where they are scarcest —
+        # ``genera_ui`` averages ~5 250 input tokens against a 6 000/min free-tier
+        # ceiling, and the whole document is most of that.
+        return clip_source(_scoped_full_text(document.full_text, node.source_headings))
 
     repo = DocumentChunkRepository(db)
     embedder = maybe_fixture_embedder(resolve_embedding_config(await _org_settings(db, org_id)))
@@ -196,6 +204,21 @@ async def load_source_context(db: Any, node: CourseNode, org_id: uuid.UUID) -> s
             self.content = content
 
     return clip_source(assemble_chunk_text([_Chunk(row["content"]) for row in rows]))
+
+
+#: A scoped section shorter than this is treated as a bad match and the whole document is
+#: kept. Narrowing to two sentences would starve the generator of the material it has to
+#: teach from, and ``SkillNet 13`` then leaves it nothing to say — a worse failure than
+#: carrying a few hundred tokens too many.
+MIN_SCOPED_SOURCE_CHARS = 200
+
+
+def _scoped_full_text(full_text: str, headings: Any) -> str:
+    """The node's own sections of a short document, or all of it when that is not safe."""
+    scoped = focus_on_headings(full_text, list(headings or ()))
+    if len(scoped.strip()) < MIN_SCOPED_SOURCE_CHARS:
+        return full_text
+    return scoped
 
 
 def split_answer_key(raw: str) -> tuple[str, dict]:
@@ -460,6 +483,21 @@ async def decide_formato(state: NodeRuntimeState) -> dict:
     would still cost a call, and the reason for the rule is pedagogical, not economic: the
     learner has to build a mental map before the interface starts moving (the lesson of
     Office 2000's adaptive menus).
+
+    **The shape of the material is read on every path, calibrating or not** (§4.2, defect
+    of 2026-07-28). Until then the calibration branch chose the screen with *zero*
+    knowledge of the content: ``default_ui_format`` is written by the schema agent when the
+    course is created and never looked at again. Measured on the seeded courses, that is
+    not a theoretical gap — ``Coordinacion con cocina y tiempos`` is declared ``chart`` and
+    its section writes every figure as a word ("doce minutos", "dieciocho"), so there is
+    not one digit for a chart to plot and the generator could only have invented them.
+
+    Reading the source here does not weaken the calibration rule, and it is worth being
+    precise about why: §6.4 freezes adaptation **to the learner**. A shape derived from the
+    node's own material is the same for every learner and on every visit, so the interface
+    still does not move under anyone. It also costs no call, which matters more than it
+    looks — the free tier's ceiling is tokens per minute, and a second call to pick a shape
+    would spend the quota the generation itself needs.
     """
     request_id = str(state["request_id"])
     node = state.get("node") or {}
@@ -469,10 +507,29 @@ async def decide_formato(state: NodeRuntimeState) -> dict:
     #: Empty during calibration: no call was made, so there is nothing to account for.
     decide_tokens: dict[str, int] = {}
 
+    plan = analyze_shape(
+        source_context=str(state.get("source_context") or ""),
+        summary=str(node.get("summary") or ""),
+        headings=list(node.get("source_headings") or ()),
+    )
+
     if is_calibrating(int(profile.get("nodes_completed") or 0)):
-        ui_format = default_format
+        ui_format, correction = refine_format(
+            default_format,
+            plan,
+            criticality=str(node.get("criticality") or "recommended"),
+        )
         tier = select_tier(ui_format)
         rationale = "calibracion: se usa el formato por defecto del nodo (§6.4)"
+        if correction:
+            rationale = f"calibracion, corregido: {correction}"
+            logger.info(
+                "Node %s declares default_ui_format=%r but %s; serving %r instead",
+                node.get("id"),
+                default_format,
+                correction,
+                ui_format,
+            )
     else:
         org_id = _uuid(state["org_id"])
         llm = await _make_llm(org_id, "fast")
@@ -493,6 +550,7 @@ async def decide_formato(state: NodeRuntimeState) -> dict:
             consecutive_failed=int(node_state.get("consecutive_failed") or 0),
             last_error_kind=node_state.get("last_error_kind"),
             source_has_numbers=_source_has_numbers(str(state.get("source_context") or "")),
+            shape_summary=plan.summary if plan else "",
         )
         started = time.monotonic()
         raw, usage = await llm.complete_with_usage(
@@ -546,6 +604,11 @@ async def decide_formato(state: NodeRuntimeState) -> dict:
         "ui_format": ui_format,
         "tier": tier,
         "format_rationale": rationale,
+        # Computed once here and carried, so `genera_ui` and its one repair attempt read
+        # the same analysis. Re-deriving it in the retry would re-scan the source for a
+        # result that cannot have changed.
+        "shape_hints": list(plan.hints(ui_format)),
+        "shape_summary": plan.summary,
         "current_step": "decide_formato",
         # Carried so `node_renders.tokens_*` is the cost of the *render*, not of one of the
         # two calls that produced it. `genera_ui` adds its own on top, retries included.
@@ -586,12 +649,15 @@ async def genera_ui(state: NodeRuntimeState) -> dict:
         node.get("criticality") or "recommended", node.get("mastery_threshold")
     )
 
+    shape_hints = list(state.get("shape_hints") or ())
+
     if retry:
         system = ui_repair_system()
         user_prompt = build_repair_prompt(
             previous=str(state.get("raw_dsl") or ""),
             errors=list(state.get("validation_errors") or []),
             ui_format=ui_format,
+            shape_hints=shape_hints,
         )
     else:
         system = ui_generator_system()
@@ -613,6 +679,7 @@ async def genera_ui(state: NodeRuntimeState) -> dict:
             consecutive_correct=int(node_state.get("consecutive_correct") or 0),
             tutor_signals=tuple(profile.get("tutor_signals") or ()),
             source_context=str(state.get("source_context") or ""),
+            shape_hints=shape_hints,
         )
 
     await publish_step(request_id, "genera_ui", STEP_MESSAGES["genera_ui"])

--- a/apps/skillnet-api/src/agents/runtime/shape.py
+++ b/apps/skillnet-api/src/agents/runtime/shape.py
@@ -1,0 +1,541 @@
+"""What the node's material is *shaped* like, decided before a token is spent.
+
+Why this module exists
+======================
+
+On 2026-07-27 the first node of the seeded ``Alergenos`` course was served to a real
+learner as four valid blocks: a lead line, a paragraph listing all fourteen mandatory
+allergens separated by commas, a ``Callout``, and a closing paragraph. The render passed
+every check the pipeline had — ``status='ready'``, the gate clean, the contract rules
+satisfied — and it was the wrong screen. Fourteen items are a **table**, and the model had
+no way of knowing that, because nothing in the pipeline had looked at the material.
+
+Two measurements frame the fix, and they are the *same* defect seen from both sides:
+
+* Served: fourteen items flattened into one ``TextContent``. Three of the nine emittable
+  blocks were used across the whole ``node_renders`` table.
+* Rejected: on ``alergenos-hosteleria`` the model instead emitted **19 components** and on
+  ``atencion-reclamaciones`` 23 declarations, both refused by rule 4 — one block per item.
+
+So the model oscillates between "N items as one paragraph" and "N items as N blocks", and
+never finds "N items as one ``Table``". ``SkillNet 15`` names all three options in one
+sentence and lists the paragraph among them, which is the cheapest to write and the one it
+picks. Telling it after the fact costs a repair round trip; on Groq's free tier that round
+trip measured **24.7 s**, because the two calls together blow the tokens-per-minute quota.
+
+What this module does about it
+==============================
+
+It reads the node's own source and reports, deterministically and for free, the structures
+that are actually in there: an enumeration of N things, a labelled list, an ordered
+procedure, a numeric series. ``build_ui_prompt`` turns those into instructions naming the
+block, so the shape decision is made **from the content** instead of being inferred by an
+8B model from the word ``explanation``.
+
+This is the *classify* half of Curio's "classify + populate, never author markup", done
+with a regex instead of a model call. A call was the obvious alternative and it is the
+wrong one here: the thing that hurts on the free tier is tokens per minute, and a second
+call to choose a shape would spend the quota that the generation itself needs.
+
+What it deliberately does not do
+================================
+
+* **No ``Callout`` detector.** Prohibitions are trivially detectable and ``Callout`` is
+  already one of the three blocks the model over-uses. A hint that fires on every
+  compliance document would reinforce the bias this module exists to break.
+* **No invented data.** A signal reports what the source *has*. ``SkillNet 13`` forbids
+  inventing figures, and a hint that asked for a ``Chart`` the source cannot fill would be
+  asking the model to break it.
+* **No per-learner adaptation.** Every signal here is a property of the node, identical for
+  everyone who opens it. That is what keeps this compatible with the calibration period of
+  §6.4: the interface may not move under a learner who is still building a mental map, and
+  a shape derived from the material does not move — it is the same shape for every learner
+  and on every visit.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+# --- thresholds ---------------------------------------------------------------------
+#
+# Every one of these is a false-positive guard, measured against the ten briefs of
+# ``scripts/quality_bench.py`` plus the two seeded courses. The failure mode to avoid is
+# not "missed a table"; it is "told the model to build a table out of ordinary prose",
+# because a hint the material cannot support sends it either to invent rows or to fight
+# the instruction.
+
+#: Items needed before a run of short fragments is a list rather than terse writing.
+MIN_ENUM_ITEMS = 4
+#: A fragment longer than this is a sentence, and a sentence ends the run.
+MAX_ENUM_ITEM_CHARS = 80
+#: ...and the run as a whole has to be *mostly* short, not just under the ceiling. Ordinary
+#: prose clears 80 chars on individual sentences but never averages 40 over four in a row.
+MAX_ENUM_MEAN_CHARS = 40
+
+#: An inline ``a, b, c, ... y z`` run. Items are shorter than in a fragment run because a
+#: comma-separated item is a noun phrase, never a clause.
+MAX_INLINE_ITEM_CHARS = 60
+
+MIN_LABELLED_ROWS = 3
+MIN_PROCEDURE_STEPS = 3
+MIN_SERIES_POINTS = 3
+
+#: A labelled row's value has to *be* a figure, not merely contain one. ``"4 grados C"`` is
+#: a data point; ``"pantalla facial completa, no solo gafas. Guantes anticorte nivel 5"``
+#: has a ``5`` in it and is a sentence. Measured on ``epi-taller``, which without this cap
+#: was reported as a three-point numeric series and would have been sent to a ``Chart``.
+MAX_SERIES_VALUE_CHARS = 30
+
+#: Only the first few hints travel. The length budget allows 3-5 blocks, so a fourth
+#: instruction would be asking for a screen the validator refuses.
+MAX_HINTS = 2
+
+
+# --- signals ------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ShapeSignal:
+    """One structure found in the source, and the kit block that renders it."""
+
+    #: ``enumeration`` | ``labelled_list`` | ``procedure`` | ``numeric_series``
+    kind: str
+    #: How many items/rows/steps/points were counted. Travels into the prompt: "14" is a
+    #: far stronger instruction than "several".
+    count: int
+    #: The block this becomes. Always one name from the frozen kit (§5.3).
+    block: str
+    #: The block to use instead when the screen is a ``chart``.
+    chart_block: str = ""
+
+    def instruction(self, ui_format: str = "explanation") -> str:
+        """The prompt line, naming the block and forbidding the two known wrong answers."""
+        block = (
+            self.chart_block
+            if self.chart_block and ui_format == "chart"
+            else self.block
+        )
+        if self.kind == "enumeration":
+            # "unos", because the count is pieces of text and an item occasionally holds
+            # two things ("altramuces y moluscos"). Asking for exactly N rows would make
+            # the model pad or split to hit a number the source does not really state.
+            # The one-column form is written out because the model got it wrong twice on
+            # the real allergen node: told to use a single column it emitted
+            # ``Table(["Alergeno"], [[...14 celdas...]])`` — one row instead of fourteen.
+            # ``SkillNet 3`` already says rows is an array of arrays; with one column that
+            # is counter-intuitive enough to need the literal shape.
+            return (
+                f"La fuente enumera una lista larga, de unos {self.count} elementos. Eso "
+                f"es UN bloque {block} con UNA FILA POR ELEMENTO. Si la fuente da un dato "
+                "de cada elemento, dos columnas; si no, una sola, y entonces cada fila es "
+                'un array de una celda: Table(["Alergeno"], [["Gluten"], ["Huevos"]]). '
+                "NO los pongas separados por comas dentro de un TextContent, y NO hagas "
+                "un bloque por elemento."
+            )
+        if self.kind == "labelled_list":
+            return (
+                f"La fuente da {self.count} pares de etiqueta y valor. Eso es UN bloque "
+                f"{block} de dos columnas, con la etiqueta en la primera. NO lo cuentes "
+                "en prosa ni hagas un bloque por par."
+            )
+        if self.kind == "procedure":
+            return (
+                f"La fuente describe un procedimiento de {self.count} pasos en orden. Eso "
+                f"es UN bloque {block}, un paso por elemento y en el orden de la fuente. "
+                "NO lo narres en un parrafo."
+            )
+        if self.kind == "numeric_series":
+            return (
+                f"La fuente da {self.count} valores numericos comparables. Eso es UN "
+                f"bloque {block} con esas cifras EXACTAS, sin redondear y sin anadir "
+                "ninguna que no este en la fuente."
+            )
+        return ""  # pragma: no cover - the four kinds above are the closed set
+
+
+@dataclass(frozen=True)
+class ShapePlan:
+    """Everything the material said about its own shape."""
+
+    signals: tuple[ShapeSignal, ...] = ()
+    #: Whether the source carries digits at all — the honest input to the ``chart`` rule.
+    has_numbers: bool = False
+
+    def __bool__(self) -> bool:
+        return bool(self.signals)
+
+    @property
+    def blocks(self) -> tuple[str, ...]:
+        """The kit blocks this material asks for, in order of confidence."""
+        return tuple(dict.fromkeys(signal.block for signal in self.signals))
+
+    def hints(self, ui_format: str = "explanation") -> tuple[str, ...]:
+        """The prompt lines, capped at :data:`MAX_HINTS`."""
+        return tuple(
+            signal.instruction(ui_format) for signal in self.signals[:MAX_HINTS]
+        )
+
+    @property
+    def summary(self) -> str:
+        """One line for a log or a rationale, never for a prompt."""
+        if not self.signals:
+            return "sin estructura detectada"
+        return ", ".join(f"{s.kind}x{s.count}->{s.block}" for s in self.signals)
+
+
+# --- text helpers ---------------------------------------------------------------------
+
+
+def fold(text: str) -> str:
+    """Lowercase and strip accents, so ``Fase``/``fase`` and ``párrafo``/``parrafo`` match.
+
+    Real customer documents carry accents; the bench corpus does not. A detector that only
+    worked on one of the two would pass its tests and miss production.
+    """
+    decomposed = unicodedata.normalize("NFD", text)
+    return "".join(c for c in decomposed if not unicodedata.combining(c)).lower()
+
+
+#: A fragment that is only a number, a bullet or an ordinal is punctuation, not an item.
+#: ``"1. Plazo. El cliente dispone..."`` splits to ``["1", "Plazo", "El cliente..."]`` and
+#: without this the ``"1"`` counts as a very short item and drags the mean down.
+_NOISE_FRAGMENT_RE = re.compile(r"^[\W\d_]*$")
+
+#: Paragraph break. Runs are counted **inside** a paragraph: a heading followed by the
+#: first three sentences of a section is not a list, and every false positive found while
+#: writing this module was of exactly that shape.
+_PARAGRAPH_RE = re.compile(r"\n\s*\n")
+
+#: Sentence/clause break inside a paragraph. Semicolons count: ``"a; b; c"`` is a list.
+_FRAGMENT_RE = re.compile(r"[.;]+")
+
+#: A labelled row **must** carry a bullet marker, and that is a deliberate loss of recall.
+#:
+#: Without the marker the pattern matches any line holding a colon, and a paragraph is a
+#: line: measured on ``prevencion-riesgos`` it collected ``"Factores que agravan el
+#: riesgo: ..."`` and ``"5. No girar el tronco con la carga en alto: mover los pies"`` and
+#: reported a three-row table that does not exist. The asymmetry is the reason to accept
+#: the loss — a missed hint costs nothing (the prompt falls back to what it says today),
+#: while a hint the material cannot support sends the model to invent rows.
+_LABELLED_RE = re.compile(
+    r"^[ \t]*[-*•·]\s*([^:\n]{2,60}?)\s*:\s*(\S[^\n]*)$", re.MULTILINE
+)
+_NUMBERED_RE = re.compile(r"^[ \t]*(\d{1,2})[.)]\s+\S", re.MULTILINE)
+#: ``P - Quitar el Pasador`` — the mnemonic-procedure shape (the extintor brief's PAS).
+_LETTER_STEP_RE = re.compile(r"^[ \t]*([A-Za-z])\s*[-–]\s+\S", re.MULTILINE)
+_WORD_STEP_RE = re.compile(r"\b(?:paso|fase|etapa)\s+(\d{1,2})\b")
+_DIGIT_RE = re.compile(r"\d")
+
+
+def _fragments(paragraph: str) -> list[str]:
+    """A paragraph split into clause-sized pieces, noise dropped."""
+    pieces = (piece.strip() for piece in _FRAGMENT_RE.split(paragraph))
+    return [
+        piece
+        for piece in pieces
+        if piece and not _NOISE_FRAGMENT_RE.match(piece)
+    ]
+
+
+# --- detectors --------------------------------------------------------------------
+
+
+def _detect_enumeration(source: str) -> ShapeSignal | None:
+    """The longest run of consecutive short fragments inside one paragraph.
+
+    This is the ``Alergenos`` shape and the reason the module exists. The source reads
+    ``"Cereales con gluten (...). Crustaceos. Huevos. Pescado. Cacahuetes. Soja. ..."`` —
+    fourteen fragments averaging 22 characters, ended by an 88-character sentence about
+    which products carry them. A run is only a list if it is both **long** and **terse**,
+    which is what the two thresholds test for separately.
+    """
+    best = 0
+    for paragraph in _PARAGRAPH_RE.split(source):
+        run: list[int] = []
+        for fragment in _fragments(paragraph):
+            length = len(fragment)
+            if length <= MAX_ENUM_ITEM_CHARS:
+                run.append(length)
+                continue
+            best = max(best, _score_run(run))
+            run = []
+        best = max(best, _score_run(run))
+    if best < MIN_ENUM_ITEMS:
+        return None
+    return ShapeSignal(kind="enumeration", count=best, block="Table")
+
+
+def _score_run(run: Sequence[int]) -> int:
+    """A run's item count, or 0 when the run is prose that happens to be short."""
+    if len(run) < MIN_ENUM_ITEMS:
+        return 0
+    if sum(run) / len(run) > MAX_ENUM_MEAN_CHARS:
+        return 0
+    return len(run)
+
+
+#: A Spanish list closes with ``y``/``e``/``o``/``u`` before its last item. Used as the
+#: evidence that a comma run is an enumeration and not a sentence with commas in it.
+_LIST_TERMINATOR_RE = re.compile(r"\s(?:y|e|o|u)\s")
+
+
+def _detect_inline_enumeration(source: str) -> ShapeSignal | None:
+    """``"Los 14 alergenos son: cereales con gluten, crustaceos, huevos, ..."``.
+
+    The other enumeration shape, and the one the seeded course and the bench brief spell
+    differently: the fourteen allergens are written as fourteen sentences in the customer
+    document and as one comma-separated sentence in the brief. A detector that only knew
+    the first would have missed the exact screen this module was written for.
+
+    Commas are the most common character in prose, so two independent pieces of evidence
+    are required before a comma run counts: the run is **introduced** (a colon precedes
+    it) or **closed** the way Spanish closes a list (``... y <last>``), *and* the items are
+    short noun phrases rather than clauses.
+    """
+    best = 0
+    for paragraph in _PARAGRAPH_RE.split(source):
+        for fragment in _fragments(paragraph):
+            head, sep, tail = fragment.rpartition(":")
+            candidate = tail if sep else fragment
+            pieces = [piece.strip() for piece in candidate.split(",")]
+            pieces = [piece for piece in pieces if piece]
+            if len(pieces) < MIN_ENUM_ITEMS:
+                continue
+            if any(len(piece) > MAX_INLINE_ITEM_CHARS for piece in pieces):
+                continue
+            if sum(len(p) for p in pieces) / len(pieces) > MAX_ENUM_MEAN_CHARS:
+                continue
+            introduced = bool(sep and head.strip())
+            closed = bool(_LIST_TERMINATOR_RE.search(fold(pieces[-1])))
+            if introduced or closed:
+                best = max(best, len(pieces))
+    if best < MIN_ENUM_ITEMS:
+        return None
+    return ShapeSignal(kind="enumeration", count=best, block="Table")
+
+
+def _labelled_rows(source: str) -> list[tuple[str, str]]:
+    """``- Camara de carne: 4 grados C`` → ``("Camara de carne", "4 grados C")``.
+
+    Only rows on their **own line** count. A colon mid-paragraph is punctuation
+    (``"La consigna es siempre: avisar, evacuar..."``), and treating it as a table row is
+    how a detector starts inventing structure that is not there.
+    """
+    rows: list[tuple[str, str]] = []
+    for match in _LABELLED_RE.finditer(source):
+        label, value = match.group(1).strip(), match.group(2).strip()
+        if label and value:
+            rows.append((label, value))
+    return rows
+
+
+def _detect_labelled(source: str) -> ShapeSignal | None:
+    rows = _labelled_rows(source)
+    if len(rows) < MIN_LABELLED_ROWS:
+        return None
+    return ShapeSignal(kind="labelled_list", count=len(rows), block="Table")
+
+
+def _detect_numeric_series(source: str) -> ShapeSignal | None:
+    """Labelled rows whose value is a figure — the only honest basis for a ``Chart``.
+
+    Requires the *values* to carry digits, not the paragraph around them: a section that
+    happens to cite ``Reglamento 1169/2011`` has digits and no series.
+    """
+    points = [
+        (label, value)
+        for label, value in _labelled_rows(source)
+        if _DIGIT_RE.search(value) and len(value) <= MAX_SERIES_VALUE_CHARS
+    ]
+    if len(points) < MIN_SERIES_POINTS:
+        return None
+    return ShapeSignal(
+        kind="numeric_series", count=len(points), block="Table", chart_block="Chart"
+    )
+
+
+def _detect_procedure(source: str) -> ShapeSignal | None:
+    """Ordered steps: ``1.`` lines, ``Paso N``/``Fase N``, or the ``P - ...`` mnemonic."""
+    numbered = _NUMBERED_RE.findall(source)
+    if len(numbered) >= MIN_PROCEDURE_STEPS:
+        return ShapeSignal(
+            kind="procedure", count=len(numbered), block="StepSequence"
+        )
+    worded = _WORD_STEP_RE.findall(fold(source))
+    if len(worded) >= MIN_PROCEDURE_STEPS:
+        return ShapeSignal(kind="procedure", count=len(worded), block="StepSequence")
+    lettered = _LETTER_STEP_RE.findall(source)
+    if len(lettered) >= MIN_PROCEDURE_STEPS:
+        return ShapeSignal(kind="procedure", count=len(lettered), block="StepSequence")
+    return None
+
+
+# --- the plan ----------------------------------------------------------------------
+
+
+#: A paragraph that is one short line without a closing period is a section heading.
+#: Matches ``"Marco legal"`` and ``"Contaminacion cruzada en el obrador"`` and not the
+#: bodies under them, which are multi-sentence and end in '.'.
+MAX_HEADING_CHARS = 80
+
+
+def _looks_like_heading(paragraph: str) -> bool:
+    text = paragraph.strip()
+    return (
+        bool(text)
+        and "\n" not in text
+        and len(text) <= MAX_HEADING_CHARS
+        and not text.endswith((".", ":", ";"))
+    )
+
+
+def focus_on_headings(source: str, headings: Sequence[str]) -> str:
+    """The sections of ``source`` that belong to this node, or all of it when unsure.
+
+    A document of five pages or fewer travels **whole** into every node's prompt
+    (``load_source_context`` takes the ``full_text`` branch), so all three nodes of the
+    seeded ``Alergenos`` course see the same text. Without this, the node about
+    cross-contamination would be told to build a table of fourteen allergens, because the
+    allergens are in the source it was handed — true, and not what that node is about.
+
+    ``course_nodes.source_headings`` is the node's own claim on part of the document and
+    the same key retrieval uses for the chunked branch, so it is the honest scope. When
+    nothing matches, the whole source is returned: a hint drawn from too much text is a
+    smaller error than no hint at all, and the thresholds still have to clear.
+    """
+    wanted = [fold(h).strip() for h in headings if h and h.strip()]
+    if not wanted or not source.strip():
+        return source
+
+    paragraphs = _PARAGRAPH_RE.split(source)
+    kept: list[str] = []
+    collecting = False
+    for paragraph in paragraphs:
+        if _looks_like_heading(paragraph):
+            folded = fold(paragraph).strip()
+            collecting = any(
+                folded in heading or heading in folded for heading in wanted
+            )
+            if collecting:
+                kept.append(paragraph)
+            continue
+        if collecting:
+            kept.append(paragraph)
+    return "\n\n".join(kept) if kept else source
+
+
+def analyze_shape(
+    *, source_context: str = "", summary: str = "", headings: Sequence[str] = ()
+) -> ShapePlan:
+    """Read the node's material and report the structures in it.
+
+    ``summary`` is appended because a node whose document did not survive retrieval still
+    has its own one-line description, and an enumeration is sometimes stated there. The
+    source dominates: it is the only text the generator is allowed to draw facts from.
+
+    Ordering is by **specificity**, not by count. A numeric series is a labelled list with
+    figures in it, and a labelled list is an enumeration with two columns; reporting the
+    weaker reading of the same paragraph as a second hint would spend the budget saying
+    the same thing twice, so each paragraph shape contributes once.
+    """
+    scoped = focus_on_headings(source_context, headings)
+    text = "\n\n".join(part for part in (scoped, summary) if part.strip())
+    if not text.strip():
+        return ShapePlan()
+
+    ordered: list[ShapeSignal] = []
+    series = _detect_numeric_series(text)
+    labelled = _detect_labelled(text)
+    procedure = _detect_procedure(text)
+    # The two spellings of the same structure; the longer run is the better evidence.
+    runs = [
+        signal
+        for signal in (_detect_enumeration(text), _detect_inline_enumeration(text))
+        if signal is not None
+    ]
+    enumeration = max(runs, key=lambda signal: signal.count) if runs else None
+
+    # A numeric series and a labelled list are the same rows read twice: keep the stronger.
+    table_signal = series or labelled
+    if table_signal is not None:
+        ordered.append(table_signal)
+    if procedure is not None:
+        ordered.append(procedure)
+    # An enumeration only adds something when no table shape was found: the fourteen
+    # allergens are a run of fragments and produce no labelled rows at all, which is
+    # exactly the case this last branch is for.
+    if enumeration is not None and table_signal is None:
+        ordered.append(enumeration)
+
+    return ShapePlan(
+        signals=tuple(ordered), has_numbers=bool(_DIGIT_RE.search(scoped))
+    )
+
+
+# --- format refinement ---------------------------------------------------------------
+
+#: Formats whose screen is only possible when the source carries figures (§4.2, rule 1 of
+#: ``FORMAT_DECIDER_SYSTEM``).
+_NEEDS_NUMBERS = "chart"
+
+
+def refine_format(
+    default_format: str, plan: ShapePlan, *, criticality: str = "recommended"
+) -> tuple[str, str]:
+    """Correct a hand-written ``default_ui_format`` the material flatly contradicts.
+
+    Deliberately **narrow**, and the narrowness is the design. The obvious move after the
+    ``Alergenos`` report was to re-derive the format from the content, and it is the wrong
+    move: the screen the owner rejected was a *correct* ``explanation`` built out of the
+    wrong blocks. Format is four coarse buckets and does not determine the shape; the
+    blocks do, and those are handled by :func:`analyze_shape`. Swapping the bucket as well
+    would churn the ``cache_key`` of every seeded node for no measured gain.
+
+    So only the two cases where the declared format is **impossible** are corrected:
+
+    * ``chart`` over a source with no figures. The generator would have to invent them,
+      which ``SkillNet 13`` forbids, so the screen can only come out wrong or be refused.
+      Outside calibration ``decide_formato`` already guards this by telling the model
+      whether the source has figures; during calibration nothing did, and this closes it.
+    * ``chart`` on a ``critical`` node, which ``FORMAT_DECIDER_SYSTEM`` forbids outright
+      and which the calibration short-circuit was quietly bypassing.
+
+    Returns ``(format, rationale)``; the rationale is stored, never prompted.
+    """
+    if default_format != _NEEDS_NUMBERS:
+        return default_format, ""
+    if criticality == "critical":
+        return (
+            "explanation",
+            "el nodo es critical y un critical no se presenta solo como chart",
+        )
+    if not plan.has_numbers:
+        return (
+            "explanation",
+            "la fuente no trae cifras representables y un chart tendria que inventarlas",
+        )
+    return default_format, ""
+
+
+__all__ = [
+    "MAX_ENUM_ITEM_CHARS",
+    "MAX_ENUM_MEAN_CHARS",
+    "MAX_HEADING_CHARS",
+    "MAX_HINTS",
+    "MAX_INLINE_ITEM_CHARS",
+    "MAX_SERIES_VALUE_CHARS",
+    "MIN_ENUM_ITEMS",
+    "MIN_LABELLED_ROWS",
+    "MIN_PROCEDURE_STEPS",
+    "MIN_SERIES_POINTS",
+    "ShapePlan",
+    "ShapeSignal",
+    "analyze_shape",
+    "focus_on_headings",
+    "fold",
+    "refine_format",
+]

--- a/apps/skillnet-api/src/agents/runtime/state.py
+++ b/apps/skillnet-api/src/agents/runtime/state.py
@@ -39,6 +39,13 @@ class NodeRuntimeState(TypedDict, total=False):
     ui_format: Literal["explanation", "simulation", "exercise", "chart", "mixed"]
     tier: Literal["fast", "heavy"]
     format_rationale: str
+    #: What ``src/agents/runtime/shape.py`` found in *this node's* section of the source:
+    #: one instruction per structure, already naming the kit block that renders it. Written
+    #: by ``decide_formato`` and read by ``genera_ui``; it is a property of the node, never
+    #: of the learner, which is what makes it safe during the calibration period (§6.4).
+    shape_hints: list[str]
+    #: One line of evidence for the log and the rationale — never for a prompt.
+    shape_summary: str
 
     # --- Generation ---
     backend: str  # "openui" (the only dialect in this PR)

--- a/apps/skillnet-api/src/llm/fixture_data/index.json
+++ b/apps/skillnet-api/src/llm/fixture_data/index.json
@@ -19,6 +19,11 @@
     "prompt_preview": "Eres el selector de formato de SkillNet, una plataforma de formacion en el puesto de trabajo. Recibes la ficha de un nodo de aprendizaje y el perfil del aprendi",
     "use_case": "decide_formato"
   },
+  "8baf14de9a97a59f": {
+    "file": "genera_ui/openui_explanation.txt",
+    "prompt_preview": "Eres el generador de pantallas de SkillNet, formacion de cumplimiento normativo para empleados. Responde UNICAMENTE con un programa en el dialecto descrito abaj",
+    "use_case": "genera_ui"
+  },
   "94b790857998d214": {
     "file": "genera_ui/openui_explanation.txt",
     "prompt_preview": "Eres el generador de pantallas de SkillNet, formacion de cumplimiento normativo para empleados. Responde UNICAMENTE con un programa en el dialecto descrito abaj",

--- a/apps/skillnet-api/src/llm/prompts/admin.py
+++ b/apps/skillnet-api/src/llm/prompts/admin.py
@@ -1,0 +1,151 @@
+"""The admin assistant's prompts: who it is, and the two things it is given to answer with.
+
+Split out of ``src/llm/prompts/tutor.py`` on 2026-07-28, because the admin assistant
+stopped being a second skin on the tutor that day. The tutor answers from *documents*; the
+admin assistant answers from documents **and** from the platform's own data
+(``src/services/org_snapshot.py``), and the rules that make the second safe have nothing
+to do with the first. ``tutor.py`` re-exports ``ADMIN_PERSONA`` and ``admin_system_prompt``
+so nothing that imported them from there had to move.
+
+The rule everything else here serves: **the assistant may not state a figure it was not
+given.** A wrong number about a named person's training record is worse than "no lo se" —
+it is a record an employer might act on. So the data block is exhaustive by construction
+(every count is pre-computed server-side; the model never adds anything up), and the
+prompt says three times, in three different shapes, that the block is the only source of
+names and numbers.
+"""
+
+from __future__ import annotations
+
+from src.llm.prompts.grounding import Grounding
+
+#: Bumped when anything here changes in a way that changes an answer. Persisted on every
+#: admin message, so "which assistant wrote this" is answerable months later — which
+#: matters more here than for the tutor, because these answers name people.
+ADMIN_PROMPT_VERSION = "admin/2"
+
+ADMIN_PERSONA = """\
+Eres el asistente del administrador de SkillNet, la plataforma de formacion interna de una
+pequena empresa espanola. Hablas con la persona que gestiona los cursos, los documentos y
+los empleados.
+
+Como respondes siempre:
+- En el idioma de la pregunta. Por defecto, espanol.
+- Conciso y operativo: que hacer, donde, en que orden.
+- En cuanto haya mas de dos pasos, los enumeras.
+
+Lo que no haces nunca:
+- No te inventas cifras, plazos ni contenido de documentos que no tengas delante.
+- No contestas "no tengo informacion" y te callas: dices que no consta y ofreces lo que
+  si puedes (criterio general, o que documento haria falta subir)."""
+
+
+#: Appended to the persona whenever a snapshot travels with the turn. The tone rule
+#: ("nombres y numeros, no consejos") is the one that fixes the reported defect: asked
+#: "como van mis empleados" with the data in front of it, a small model will still write
+#: four bullets of management advice unless it is told, in imperative, not to.
+ADMIN_DATA_BLOCK = """\
+Tienes en el contexto un bloque "DATOS DE LA PLATAFORMA": el estado real de esta
+organizacion, leido de la base de datos en este mismo momento. Es informacion de
+formacion que la empresa tiene derecho a ver sobre su plantilla.
+
+Como usarlo:
+- Si la pregunta es sobre empleados, cursos, progreso, plazos o competencias, responde
+  CON ESOS DATOS: nombres propios y numeros concretos. No des consejos de gestion
+  genericos ("habla con el encargado", "revisa las evaluaciones") cuando la respuesta
+  esta en el bloque; eso es no responder.
+- Empieza SIEMPRE por el titular: la cifra o el nombre que contesta la pregunta, en una
+  frase. El bloque "RESUMEN" ya trae esas cifras contadas; usalas tal cual. Solo despues
+  del titular viene el desglose persona a persona, y solo si aporta.
+- Cierra, como mucho, con UNA accion concreta que nombre a una persona o a un curso del
+  bloque, y que no invente plazos ni fechas que no aparezcan ahi ("escribe a Aitana, que
+  no ha abierto ninguno de sus tres cursos"). Si no tienes una asi, no cierres con nada:
+  "revisa el estado de cada empleado" no es una accion, es relleno.
+
+Los limites, que no se negocian:
+- Toda cifra que escribas tiene que estar literalmente en el bloque. No sumes, no
+  promedies, no estimes y no completes lo que falte: si un dato no esta, di que no
+  consta. Vale mas "no lo se" que un numero inventado sobre la formacion de una persona.
+- No hables de personas que no aparezcan en el bloque, ni les atribuyas cursos, notas o
+  competencias que no esten en su linea.
+- El bloque NO dice como aprende cada persona (su perfil de aprendizaje, sus preferencias
+  de formato ni sus necesidades de accesibilidad): eso es privado de cada empleado y no
+  lo tienes. Si te lo preguntan, di que la plataforma no se lo muestra al administrador.
+- No cites [Fuente N] para nada que salga de este bloque: no es un documento."""
+
+
+_GROUNDING_BLOCKS: dict[str, str] = {
+    "chunks": """\
+Ademas tienes fragmentos recuperados de la documentacion de la organizacion.
+Apoyate en ellos y cita con [Fuente N] lo que salga de ahi.""",
+    "document": """\
+Ademas tienes el texto COMPLETO de documentos de la organizacion. Apoyate en el y
+cita con [Fuente N], que aqui identifica al documento entero.""",
+    "general": """\
+No hay documentacion de la organizacion que responda a esto. Responde igualmente con
+conocimiento general o con lo que sabes de como funciona la plataforma, y di en la primera
+linea que no sale de la documentacion subida. No escribas [Fuente N].""",
+}
+
+#: Without a snapshot the grounding blocks are the whole story, so they must not open with
+#: "Ademas". Same three texts, minus the connector.
+_STANDALONE_GROUNDING_BLOCKS: dict[str, str] = {
+    "chunks": """\
+Tienes en el contexto fragmentos recuperados de la documentacion de la organizacion.
+Apoyate en ellos y cita con [Fuente N] lo que salga de ahi.""",
+    "document": """\
+Tienes en el contexto el texto COMPLETO de documentos de la organizacion. Apoyate en el y
+cita con [Fuente N], que aqui identifica al documento entero.""",
+    "general": _GROUNDING_BLOCKS["general"],
+}
+
+_CONTEXT_HEADERS: dict[str, str] = {
+    "chunks": "Fragmentos de la documentacion de la organizacion:",
+    "document": "Documentos completos de la organizacion:",
+}
+
+
+def admin_system_prompt(grounding: Grounding, *, org_data: bool = False) -> str:
+    """The admin assistant's system prompt for a turn with this grounding.
+
+    ``org_data`` defaults to ``False`` so every pre-existing caller — and the assertion in
+    ``tests/test_tutor_grounding.py`` that no prompt can produce the old refusal — keeps
+    reading the prompt it read before.
+    """
+    if not org_data:
+        return f"{ADMIN_PERSONA}\n\n{_STANDALONE_GROUNDING_BLOCKS[grounding]}"
+    return f"{ADMIN_PERSONA}\n\n{ADMIN_DATA_BLOCK}\n\n{_GROUNDING_BLOCKS[grounding]}"
+
+
+def build_admin_turn(
+    grounding: Grounding, context_block: str, snapshot_block: str, question: str
+) -> str:
+    """The final user message: the data, the documents (if any), and the question.
+
+    The snapshot goes **first** and the question **last**. Measured against small models,
+    a question buried above 1-2 kB of tabular data gets answered from the model's habits
+    rather than from the table; the last thing in the turn is the thing it answers.
+    """
+    sections: list[str] = []
+    if snapshot_block:
+        sections.append(snapshot_block)
+    if grounding != "general" and context_block:
+        sections.append(f"{_CONTEXT_HEADERS[grounding]}\n\n{context_block}")
+    if not sections:
+        return (
+            f"Pregunta: {question}\n\n"
+            "No hay material de la organizacion para esta pregunta. Respondela igual, "
+            "con criterio general, y di en la primera linea que no sale de la "
+            "documentacion subida."
+        )
+    sections.append(f"Pregunta: {question}")
+    return "\n\n---\n\n".join(sections)
+
+
+__all__ = [
+    "ADMIN_DATA_BLOCK",
+    "ADMIN_PERSONA",
+    "ADMIN_PROMPT_VERSION",
+    "admin_system_prompt",
+    "build_admin_turn",
+]

--- a/apps/skillnet-api/src/llm/prompts/admin.py
+++ b/apps/skillnet-api/src/llm/prompts/admin.py
@@ -22,7 +22,7 @@ from src.llm.prompts.grounding import Grounding
 #: Bumped when anything here changes in a way that changes an answer. Persisted on every
 #: admin message, so "which assistant wrote this" is answerable months later — which
 #: matters more here than for the tutor, because these answers name people.
-ADMIN_PROMPT_VERSION = "admin/2"
+ADMIN_PROMPT_VERSION = "admin/3"
 
 ADMIN_PERSONA = """\
 Eres el asistente del administrador de SkillNet, la plataforma de formacion interna de una
@@ -37,7 +37,25 @@ Como respondes siempre:
 Lo que no haces nunca:
 - No te inventas cifras, plazos ni contenido de documentos que no tengas delante.
 - No contestas "no tengo informacion" y te callas: dices que no consta y ofreces lo que
-  si puedes (criterio general, o que documento haria falta subir)."""
+  si puedes (criterio general, o que documento haria falta subir).
+- No copias NUNCA, tal cual, el bloque de datos de la plataforma ni el texto de los
+  documentos. Son tu material de consulta, no tu respuesta: se leen y se resumen, no se
+  pegan. Devolver el contexto entero no es responder, es vaciarlo en la pantalla.
+
+Cuando la pregunta no va de los datos, sino de ti:
+- Si te preguntan quien eres, que sabes hacer o para que sirves, la respuesta eres TU. No
+  la busques en los datos de la organizacion: ahi estan sus empleados y sus cursos, no tu
+  ficha. Di en una linea que eres el asistente de SkillNet y sigue con lo que puedes
+  mirar.
+- Si te dan una instruccion sobre el FORMATO de tu respuesta (que uses una tabla, que
+  seas mas breve, que lo maquetes de tal manera) y no te dicen SOBRE QUE, eso no es una
+  orden de volcar lo que tengas delante. Contesta en dos lineas: que el formato lo decide
+  la plataforma y no tu, y sobre que quieren esa tabla o ese resumen. Si si te dicen sobre
+  que, respondes a eso con normalidad.
+- Nunca escribas "no puedo comprender la pregunta" ni ninguna variante. Si de verdad no
+  entiendes que te piden, di con que te has quedado, ofrece la lectura mas probable y
+  propon una pregunta concreta que si puedas contestar. Un callejon sin salida no es una
+  respuesta."""
 
 
 #: Appended to the persona whenever a snapshot travels with the turn. The tone rule
@@ -49,11 +67,21 @@ Tienes en el contexto un bloque "DATOS DE LA PLATAFORMA": el estado real de esta
 organizacion, leido de la base de datos en este mismo momento. Es informacion de
 formacion que la empresa tiene derecho a ver sobre su plantilla.
 
-Como usarlo:
-- Si la pregunta es sobre empleados, cursos, progreso, plazos o competencias, responde
-  CON ESOS DATOS: nombres propios y numeros concretos. No des consejos de gestion
-  genericos ("habla con el encargado", "revisa las evaluaciones") cuando la respuesta
-  esta en el bloque; eso es no responder.
+El bloque esta SIEMPRE en el contexto, tambien cuando la pregunta no va de el. Que este
+delante no significa que haya que usarlo. Primero decide de que va la pregunta:
+
+(A) Pregunta DE GESTION: empleados, cursos, progreso, plazos, competencias, documentos
+    subidos. La contesta el bloque.
+(B) Pregunta DE CONTENIDO: que dice la norma, como se hace algo, un procedimiento, una
+    definicion. La contestan los documentos o tu criterio general. El bloque no pinta
+    nada aqui.
+(C) Pregunta SOBRE TI o instruccion sobre el formato de la respuesta. Ni bloque ni
+    documentos: mirate la persona.
+
+Si es (A):
+- Responde CON ESOS DATOS: nombres propios y numeros concretos. No des consejos de
+  gestion genericos ("habla con el encargado", "revisa las evaluaciones") cuando la
+  respuesta esta en el bloque; eso es no responder.
 - Empieza SIEMPRE por el titular: la cifra o el nombre que contesta la pregunta, en una
   frase. El bloque "RESUMEN" ya trae esas cifras contadas; usalas tal cual. Solo despues
   del titular viene el desglose persona a persona, y solo si aporta.
@@ -61,6 +89,15 @@ Como usarlo:
   bloque, y que no invente plazos ni fechas que no aparezcan ahi ("escribe a Aitana, que
   no ha abierto ninguno de sus tres cursos"). Si no tienes una asi, no cierres con nada:
   "revisa el estado de cada empleado" no es una accion, es relleno.
+
+Si es (B) o (C), la regla de cerrar con una accion NO se aplica y esta PROHIBIDA:
+- La respuesta termina cuando termina el contenido. No anadas ningun aviso sobre ningun
+  empleado, por muy cierto que sea lo que dice el bloque de el.
+- El fallo concreto que hay que evitar: te preguntan "explicame paso a paso como atender
+  una consulta de alergenos en mostrador", das los pasos bien, y cierras con "escribe a
+  Aitana, que no ha abierto ninguno de sus tres cursos". Aitana no tiene nada que ver con
+  la pregunta. Eso no es una accion util, es una respuesta que parece rota.
+- Nombra a una persona solo si te han preguntado por ella o por el grupo al que pertenece.
 
 Los limites, que no se negocian:
 - Toda cifra que escribas tiene que estar literalmente en el bloque. No sumes, no

--- a/apps/skillnet-api/src/llm/prompts/grounding.py
+++ b/apps/skillnet-api/src/llm/prompts/grounding.py
@@ -1,0 +1,20 @@
+"""The name of the rung an answer stood on. One line, its own module, on purpose.
+
+``tutor.py`` and ``admin.py`` both need it and ``tutor.py`` imports ``admin.py`` (it
+re-exports the admin persona for the callers that predate the split), so the type cannot
+live in either without a cycle. ``src/services/retrieval.py`` spells the same three values
+out inline in ``GroundedContext``; that is deliberate, because the retrieval layer must not
+import the prompt layer to describe what it found.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+#: The three rungs of the grounding ladder, best first. Persisted in
+#: ``chat_messages.metadata`` and sent to the browser as a ``grounding`` SSE event, so the
+#: bubble can say where the answer came from without the model having to be trusted to
+#: say it.
+Grounding = Literal["chunks", "document", "general"]
+
+__all__ = ["Grounding"]

--- a/apps/skillnet-api/src/llm/prompts/runtime.py
+++ b/apps/skillnet-api/src/llm/prompts/runtime.py
@@ -37,15 +37,27 @@ from functools import cache
 from typing import Any
 
 from src.render.prompt import render_prompt
+from src.render.spec import FORMATS_REQUIRING_LEAD
 
 #: Bumped whenever any prompt in this module changes in a way that changes output.
-#: Enters the ``cache_key`` (§3.4). ``runtime/3`` (2026-07-27): the closing line of
-#: ``build_ui_prompt`` stopped contradicting the answer-key protocol, the generator tail
-#: gained SkillNet 14 (ASCII ids), 15 (an inline block is a block) and 16 (a Callout tone
-#: is not the node's criticality), the length budget stopped asking for more blocks than
-#: rule 6 allows, and the repair header swapped its false "one call per line"
-#: counterexample for the two the corpus actually measured.
-PROMPT_VERSION = "runtime/3"
+#: Enters the ``cache_key`` (§3.4). ``runtime/4`` (2026-07-28): the generator prompt stopped
+#: leaving the choice of block to the model's taste. It now carries a content-to-block map
+#: with worked examples (:data:`_BLOCK_CHOICE`), SkillNet 15 stopped offering the flattened
+#: paragraph as a peer of ``Table``/``StepSequence``, and ``build_ui_prompt`` grew a
+#: ``LA FORMA DEL MATERIAL`` section fed by ``src/agents/runtime/shape.py``.
+#:
+#: The measurement behind it: the first node of the seeded ``Alergenos`` course served the
+#: fourteen mandatory allergens as one comma-separated sentence, and the same brief on the
+#: bench was refused for emitting **19 components** — one per allergen. Both are the same
+#: gap, which is that nothing ever told the model that a list of N things is one ``Table``.
+#: Across every render in ``node_renders`` the model had used 3 of the 9 emittable blocks.
+#:
+#: The same bump also carries the three fixes the 30-render baseline of that date made
+#: visible, in descending order of how often they cost a repair: the node's criticality
+#: stopped travelling as its bare enum token (:data:`_CRITICALITY_RULES` — 8 rejections,
+#: the largest single class), and SkillNet 17 and 18 name the two syntax habits behind the
+#: rest (a bare ``opciones = [...]`` declaration, and the same id declared twice).
+PROMPT_VERSION = "runtime/4"
 
 # --- budgets (§4.2) ----------------------------------------------------------------
 
@@ -113,6 +125,44 @@ _SCAFFOLD_RULES: dict[str, str] = {
         "ni repitas definiciones; esta persona ya demostro que lo domina."
     ),
 }
+
+#: Node criticality, stated as behaviour and **never as its label**.
+#:
+#: This is the highest-frequency validation failure on record, and the prompt was causing
+#: it. Measured over the 30-render baseline of 2026-07-28: eight rejections of the form
+#: ``prop 'tone' must be one of: info, warn, success (got 'critical')`` — also ``'recommended'``
+#: and ``'contextual'``. All three are the ``NodeCriticality`` enum, and the user prompt was
+#: handing the model the bare token on a line reading ``- Criticidad: critical``, four lines
+#: above a catalogue entry whose first argument is an enum. The model was not hallucinating
+#: a tone; it was copying the only enum-shaped word in front of it into the only enum slot
+#: it had.
+#:
+#: ``SkillNet 16`` was written to forbid exactly this and did not stop it, which is the
+#: lesson: a prohibition in the system prompt does not out-argue a concrete token in the
+#: user prompt. Removing the token is what removes the failure. It also costs nothing —
+#: criticality still travels, as the behaviour it is supposed to cause, which is the same
+#: pattern :data:`_SCAFFOLD_RULES` and :data:`_ERROR_RULES` already use in this module.
+_CRITICALITY_RULES: dict[str, str] = {
+    "critical": (
+        "Este nodo es de obligado cumplimiento y equivocarse tiene consecuencias reales. "
+        "Si la fuente marca un limite, una prohibicion o un caso en que hay que parar, "
+        'dale su propio aviso con Callout("warn", "..."). Uno, no tres.'
+    ),
+    "recommended": (
+        "Nodo recomendado: explica bien y no dramatices. Un Callout solo si la fuente "
+        "senala de verdad una excepcion."
+    ),
+    "contextual": (
+        "Nodo de contexto: no hace falta ningun aviso salvo que la fuente lo pida."
+    ),
+}
+
+
+def _criticality_rule(criticality: str) -> str:
+    return _CRITICALITY_RULES.get(
+        str(criticality).strip().lower(), _CRITICALITY_RULES["recommended"]
+    )
+
 
 #: How ``last_error_kind`` changes the next screen (§7.4).
 _ERROR_RULES: dict[str, str] = {
@@ -190,6 +240,7 @@ def build_format_prompt(
     consecutive_failed: int = 0,
     last_error_kind: str | None = None,
     source_has_numbers: bool = False,
+    shape_summary: str = "",
 ) -> str:
     """The user prompt for ``decide_formato``.
 
@@ -209,6 +260,15 @@ def build_format_prompt(
             f"- Criticidad: {criticality}",
             f"- Formato por defecto que eligio el creador: {default_ui_format}",
             f"- La fuente contiene cifras representables: {'si' if source_has_numbers else 'no'}",
+        ]
+    )
+    if shape_summary:
+        # Read off the source by ``src/agents/runtime/shape.py``, not guessed by a model.
+        # It is the only evidence in this prompt about what the material *is*, and it is
+        # what makes "chart" answerable rather than a coin flip.
+        parts.append(f"- Estructuras encontradas en la fuente: {shape_summary}")
+    parts.extend(
+        [
             "",
             "APRENDIZ",
             f"- Puesto: {role_title or 'sin declarar'}",
@@ -233,8 +293,48 @@ def build_format_prompt(
 
 # --- genera_ui ---------------------------------------------------------------------
 
-_UI_GENERATOR_TAIL = f"""
+#: Which block for which content, with the call written out.
+#:
+#: This section is the fix for the defect that made the owner reject the product on
+#: 2026-07-28, and every line of it is a measurement rather than a preference.
+#:
+#: The catalogue the generated artefact ships lists nine components and one worked example,
+#: and that example is ``Stack`` + ``TextContent`` + ``StepSequence`` + ``QuizItem``. So the
+#: only blocks the model has ever *seen used* are prose blocks, and the only guidance on
+#: choosing between the other six is the artefact's own "choose components that best
+#: represent the content" — which is advice, not an instruction, and an 8B model does not
+#: act on advice. Measured across the whole ``node_renders`` table: ``Stack``,
+#: ``TextContent`` and ``Callout``. Three of nine. ``Table`` never once.
+#:
+#: The rule is stated as a *mapping* and not as a list of components because the model's
+#: failure was never "did not know Table exists" — ``Table`` is in the signatures block it
+#: is given every single time. The failure was not connecting "fourteen allergens" to it.
+#: Deliberately terse, and that is a constraint and not a style. Measured on Groq's free
+#: tier: the ``genera_ui`` request already averages ~5 250 input tokens against a 6 000
+#: tokens-per-minute ceiling, and a rejected request still reserves its estimate, so a
+#: prompt that grows toward the ceiling stops fitting *at all* and every retry keeps the
+#: bucket full. The first draft of this section ran to ~420 tokens and wedged the heavy
+#: tier completely. What survives is the part that carries the instruction — the mapping
+#: and three written-out calls — with the prose around it deleted.
+_BLOCK_CHOICE = """
+## SkillNet: que bloque para que contenido
 
+Elige el bloque por lo que ES el material. Un contenido en el bloque equivocado es una
+pantalla mal hecha aunque el programa sea valido.
+
+- LISTA de cosas (los N alergenos, los contenedores, los EPI por tarea) -> UN Table, una
+  fila por cosa; segunda columna solo si la fuente da un dato de cada una.
+  Table(["Alergeno", "Donde aparece"], [["Cereales con gluten", "Masa y bolleria"], ["Leche", "Hojaldre"]])
+- PROCEDIMIENTO en orden -> UN StepSequence de 2 a 7 pasos.
+  StepSequence("Uso del extintor", ["Quitar el pasador", "Apuntar a la base", "Barrer"])
+- CIFRAS comparables, y solo si estan en la fuente -> UN Chart.
+  Chart("bar", "Temperatura por camara", ["Carne", "Pescado"], [4, 2])
+- REGLA CRITICA o excepcion -> UN Callout. Bloques que se leen juntos -> UN Card.
+- TextContent es prosa: la frase de entrada y el matiz. NUNCA una lista.
+"""
+
+_UI_GENERATOR_TAIL = f"""
+{_BLOCK_CHOICE}
 ## SkillNet: tres reglas que el catalogo de arriba no dice
 
 - SkillNet 14 — El id de un bloque se escribe en ASCII, sin tildes ni enes: `conclusion`,
@@ -242,13 +342,20 @@ _UI_GENERATOR_TAIL = f"""
   aprendiz no lo ve nunca. Los TEXTOS entre comillas si llevan tildes: escribe el espanol
   correcto en todo lo que se lee.
 - SkillNet 15 — Un bloque escrito EN LINEA dentro del array de hijos de otro cuenta como
-  un bloque para el limite de 12. Una lista de N cosas es UN bloque, no N: un StepSequence,
-  un Table, o un solo TextContent cuyo texto lleve la enumeracion. Nunca un TextContent
-  por elemento.
+  un bloque para el limite de 12. Una lista de N cosas es UN bloque, no N: el Table o el
+  StepSequence de la seccion de arriba. Nunca un TextContent por elemento, y tampoco los N
+  elementos separados por comas dentro de un TextContent: eso cumple el limite y deshace
+  la lista, que es peor. Meter la lista en su bloque es lo que arregla las dos cosas.
 - SkillNet 16 — El PRIMER argumento de Callout es el tono, y solo hay tres: "info", "warn"
   y "success". La criticidad del nodo NO es un tono: "critical", "recommended" y
   "contextual" no valen ahi. Un nodo critical se avisa con Callout("warn", "..."), y el
   texto del aviso va en el SEGUNDO argumento, nunca en el primero.
+- SkillNet 17 — A la derecha del `=` va SIEMPRE una llamada a un bloque. No hay variables
+  sueltas; el array se escribe dentro del bloque que lo usa.
+  MAL:  opciones = ["A", "B"]
+  BIEN: q1 = QuizItem("q1", "test", "apply", "Cual?", ["A", "B"])
+- SkillNet 18 — Cada id se declara UNA sola vez, `root` incluido. Dos lineas con el mismo
+  id invalidan el programa: usa nombres distintos (`pregunta1`, `pregunta2`).
 
 ## SkillNet: la clave de respuestas
 
@@ -367,6 +474,7 @@ def build_ui_prompt(
     consecutive_correct: int = 0,
     tutor_signals: Sequence[str] = (),
     source_context: str = "",
+    shape_hints: Sequence[str] = (),
 ) -> str:
     """The user prompt for ``genera_ui``.
 
@@ -374,6 +482,13 @@ def build_ui_prompt(
     literally (§3.3, §6.2): they are what the examples get framed around, and the reason
     ``role_bucket`` is part of the ``cache_key``. ``goal`` and ``accessibility`` do not
     travel, by design.
+
+    ``shape_hints`` come from :func:`src.agents.runtime.shape.analyze_shape` and are the
+    one part of this prompt derived from reading the source rather than from describing
+    the learner. They are placed **immediately before** the source and after everything
+    else, because that is the last thing the model reads before the material itself, and
+    the ordering is the same reason :func:`_closing_line` exists: on an 8B model the
+    instruction nearest the content wins.
     """
     parts = [
         f"FORMATO QUE DEBES PRODUCIR: {ui_format}",
@@ -384,7 +499,9 @@ def build_ui_prompt(
     ]
     if outcome:
         parts.append(f"- Resultado esperado: {outcome}")
-    parts.append(f"- Criticidad: {criticality}")
+    # NOT ``- Criticidad: critical``. See ``_CRITICALITY_RULES``: the bare enum token on
+    # this line was being copied straight into ``Callout("critical", ...)``.
+    parts.append(f"- {_criticality_rule(criticality)}")
 
     parts.extend(
         [
@@ -419,6 +536,11 @@ def build_ui_prompt(
         if rule:
             parts.append(f"- {rule}")
 
+    shape_section = _shape_section(shape_hints, ui_format)
+    if shape_section:
+        parts.append("")
+        parts.extend(shape_section)
+
     parts.append("")
     if source_context.strip():
         parts.append("FUENTE (es la unica verdad; no anadas datos que no esten aqui)")
@@ -435,6 +557,38 @@ def build_ui_prompt(
 
 #: The formats whose screen carries a ``QuizItem``, and therefore an answer key.
 _FORMATS_WITH_QUIZ: frozenset[str] = frozenset({"exercise", "mixed"})
+
+
+def _shape_section(shape_hints: Sequence[str], ui_format: str) -> list[str]:
+    """The ``LA FORMA DEL MATERIAL`` block, or ``[]`` when the source had no structure.
+
+    Shared by the first turn and the repair turn: the material does not change between
+    them, and the repair is the turn where "those 14 items are one Table" matters most.
+
+    The closing line about the lead slot is not decoration. Measured end to end on the
+    real ``Los catorce alergenos obligatorios`` node the first time these hints ran: the
+    model obeyed the hint, opened the screen with the ``Table``, and was refused **twice**
+    for contract rule 7 — *"requires the first child of root to be a TextContent with
+    variant='lead' or a Callout. Got Table"* — and fell back to the seed lesson. The hints
+    sit last in the prompt precisely because the nearest instruction wins on an 8B model,
+    and that is exactly how they out-shouted a rule they were never meant to touch. Rule 7
+    is stated in the system prompt (``SkillNet 8``); it has to be restated *here*, next to
+    the instruction that competes with it, or the two keep fighting on every render.
+    """
+    hints = [str(hint).strip() for hint in shape_hints if str(hint).strip()]
+    if not hints:
+        return []
+    lines = [
+        "LA FORMA DEL MATERIAL (leido de la fuente, no es una preferencia de estilo)"
+    ]
+    lines.extend(f"- {hint}" for hint in hints)
+    if ui_format in FORMATS_REQUIRING_LEAD:
+        lines.append(
+            "- El PRIMER bloque de la pantalla sigue siendo la linea de entrada "
+            '(TextContent con variant "lead", o un Callout). El bloque de la lista va '
+            "DESPUES de esa linea, nunca el primero."
+        )
+    return lines
 
 
 def _closing_line(ui_format: str) -> str:
@@ -461,7 +615,11 @@ def _closing_line(ui_format: str) -> str:
 
 
 def build_repair_prompt(
-    *, previous: str, errors: Sequence[str], ui_format: str = "explanation"
+    *,
+    previous: str,
+    errors: Sequence[str],
+    ui_format: str = "explanation",
+    shape_hints: Sequence[str] = (),
 ) -> str:
     """The user prompt for the single repair attempt.
 
@@ -474,12 +632,22 @@ def build_repair_prompt(
     too, including on the turn whose *only* complaint was a missing answer key. Telling a
     model to fix a missing key and then telling it to send only the program is asking it
     to fail twice.
+
+    ``shape_hints`` are repeated here rather than assumed remembered. The single most
+    expensive rejection measured on real Groq is rule 4 with a large count —
+    ``alergenos-hosteleria`` came back with 19 components and ``atencion-reclamaciones``
+    with 23 declarations, both of them a list written as one block per item. "You have too
+    many blocks" tells the model to delete content; "those N items are one Table" tells it
+    what to do instead, and it is the only message that ends that loop in one attempt.
     """
     listed = "\n".join(f"- {error}" for error in errors) or "- programa invalido"
+    section = _shape_section(shape_hints, ui_format)
+    reminder = "\n".join(section) + "\n\n" if section else ""
     return (
         f"FORMATO QUE DEBES PRODUCIR: {ui_format}\n\n"
         "ERRORES DEL VALIDADOR:\n"
         f"{listed}\n\n"
+        f"{reminder}"
         "TU RESPUESTA ANTERIOR:\n"
         f"{previous}\n\n"
         f"Vuelve a emitir el programa completo y corregido. {_closing_line(ui_format)}"

--- a/apps/skillnet-api/src/llm/prompts/tutor.py
+++ b/apps/skillnet-api/src/llm/prompts/tutor.py
@@ -171,7 +171,13 @@ CHAT_UI_RULES = f"""\
 
 
 def chat_ui_system() -> str:
-    """The generated artefact plus the chat overrides. Same catalogue as a node render."""
+    """The generated artefact plus the chat overrides. Same catalogue as a node render.
+
+    Kept, unused by ``ChatService`` since the chat moved to :data:`CHAT_SHAPES` below, for
+    the node runtime's sake: this is the text that documents what "author the program
+    yourself" asks of a model, and the rules in it are still the rules the node prompt
+    plays by. Deleting it would delete the comparison.
+    """
     return render_prompt().rstrip() + "\n" + CHAT_UI_RULES
 
 
@@ -185,14 +191,115 @@ def build_chat_ui_prompt(question: str, answer: str) -> str:
     )
 
 
+# --------------------------------------------------------------------------------------
+# The layout call, second attempt: classify + populate (2026-07-28)
+# --------------------------------------------------------------------------------------
+#: The shapes a chat answer can take. Five, closed, and the fifth is "none of these".
+#:
+#: **Why this replaced asking for a program.** Everything above asks the model to *author*
+#: OpenUI Lang: identifiers, a reference graph, arity, quoting, a line budget. Measured on
+#: this repository's own node-render bench (``bench_out/runs/*.json``, 22 runs against
+#: ``groq/llama-3.1-8b-instant`` and ``groq/openai/gpt-oss-120b``): 5 runs fell back to
+#: prose and 3 more needed the repair attempt, and **all ten validator errors in the
+#: failure dumps are markup-authoring errors** — named arguments (``Stack(children = ...)``),
+#: an accent inside a bare identifier, ``{`` for an object, twice the line cap. Not one is
+#: "the model picked the wrong block" or "the model got the content wrong". The model's
+#: judgement about *shape* was never the failing part; its typing was.
+#:
+#: So the model no longer types. It returns one JSON object naming a shape and filling
+#: that shape's fields, and ``src/services/chat_service.py`` writes the program. Every
+#: failure class above becomes unrepresentable rather than rejected. This is Curio's
+#: "classify + populate, never author markup" (``docs/ARCHITECTURE.md``), narrowed to the
+#: one place in SkillNet where the answer really does have five shapes.
+#:
+#: Curio splits it into two calls because it runs 1-4B models locally and a smaller schema
+#: fills better. Here it is **one** call returning a tagged union: the models are an order
+#: of magnitude larger, the layout is a second call the learner is already reading past,
+#: and doubling its latency and its rate-limit exposure to shrink a five-branch enum is
+#: the wrong trade. Splitting it later needs no change outside this module and the emitter.
+CHAT_SHAPES: tuple[str, ...] = ("steps", "table", "callout", "definition", "prose")
+
+#: Caps enforced **again** in the emitter. Stated here so the model aims inside them, and
+#: re-checked there because a prompt is a request and the emitter is the guarantee.
+MAX_STEPS = 7
+MAX_TABLE_COLUMNS = 4
+MAX_TABLE_ROWS = 8
+MAX_DEFINITION_POINTS = 6
+
+CHAT_LAYOUT_SYSTEM = f"""\
+Eres un maquetador. NO escribes codigo, ni HTML, ni ningun lenguaje de marcado. Devuelves
+UN objeto JSON y nada mas.
+
+Te dan una pregunta y la respuesta que el asistente acaba de dar. Tu unico trabajo es
+elegir que FORMA tiene esa respuesta y rellenar los campos de esa forma con texto que ya
+esta en ella.
+
+Reglas que no se negocian:
+- No anades informacion. No cambias ninguna cifra, ningun nombre, ninguna fecha y ningun
+  plazo. Si un dato no esta en la respuesta, no aparece en el JSON.
+- No copias los marcadores [Fuente N]: las fuentes se pintan aparte.
+- Escribes en el mismo idioma que la respuesta.
+- Si dudas entre una forma y "prose", eliges "prose". Maquetar por maquetar hace la
+  respuesta mas lenta y mas dificil de leer.
+
+Las cinco formas:
+
+1) "steps" — la respuesta es un procedimiento con pasos en orden.
+   {{"shape": "steps", "lead": "<una frase que resume la respuesta>",
+     "title": "<titulo corto del procedimiento>",
+     "steps": ["<paso 1>", "<paso 2>"]}}
+   Entre 2 y {MAX_STEPS} pasos. Un paso es una frase, no un parrafo.
+
+2) "table" — la respuesta compara dos o mas cosas, o son filas con las mismas columnas
+   (por ejemplo una persona por fila y su estado en columnas).
+   {{"shape": "table", "lead": "<una frase>",
+     "headers": ["<columna>", "<columna>"],
+     "rows": [["<celda>", "<celda>"]]}}
+   Entre 2 y {MAX_TABLE_COLUMNS} columnas y entre 2 y {MAX_TABLE_ROWS} filas. TODAS las
+   filas tienen exactamente tantas celdas como cabeceras.
+
+3) "callout" — la respuesta es UNA regla critica, un limite o una excepcion.
+   {{"shape": "callout", "lead": "<una frase>", "tone": "info" | "warn" | "success",
+     "text": "<la regla>"}}
+   "warn" si es un riesgo o una prohibicion, "success" si es una confirmacion, "info" en
+   el resto.
+
+4) "definition" — la respuesta define o enumera conceptos, cada uno con su explicacion.
+   {{"shape": "definition", "lead": "<una frase>", "title": "<titulo corto>",
+     "points": [{{"term": "<concepto>", "detail": "<que es>"}}]}}
+   Entre 2 y {MAX_DEFINITION_POINTS} puntos.
+
+5) "prose" — ninguna de las anteriores. Un parrafo suelto, una sola idea, una pregunta de
+   vuelta, o una respuesta que ya se lee bien tal cual.
+   {{"shape": "prose"}}
+
+Devuelve solo el objeto JSON."""
+
+
+def build_chat_layout_prompt(question: str, answer: str) -> str:
+    """The populate turn: the question asked and the answer that was just streamed."""
+    return (
+        f"Pregunta:\n{question}\n\n"
+        f"Respuesta que se acaba de dar:\n{answer}\n\n"
+        "Elige la forma de esa respuesta y rellena sus campos. Solo el JSON."
+    )
+
+
 __all__ = [
     "ADMIN_PERSONA",
+    "CHAT_LAYOUT_SYSTEM",
+    "CHAT_SHAPES",
     "CHAT_UI_RULES",
+    "MAX_DEFINITION_POINTS",
+    "MAX_STEPS",
+    "MAX_TABLE_COLUMNS",
+    "MAX_TABLE_ROWS",
     "NO_UI_SENTINEL",
     "TUTOR_PERSONA",
     "TUTOR_PROMPT_VERSION",
     "Grounding",
     "admin_system_prompt",
+    "build_chat_layout_prompt",
     "build_chat_ui_prompt",
     "build_user_turn",
     "chat_ui_system",

--- a/apps/skillnet-api/src/llm/prompts/tutor.py
+++ b/apps/skillnet-api/src/llm/prompts/tutor.py
@@ -28,14 +28,9 @@ untouched, so no cached render is invalidated by anything in this file.
 
 from __future__ import annotations
 
-from typing import Literal
-
+from src.llm.prompts.admin import ADMIN_PERSONA, admin_system_prompt
+from src.llm.prompts.grounding import Grounding
 from src.render.prompt import render_prompt
-
-#: The three rungs of the ladder, best first. Persisted in ``chat_messages.metadata`` and
-#: sent to the browser as a ``grounding`` SSE event, so the bubble can say where it came
-#: from without the model having to be trusted to say it.
-Grounding = Literal["chunks", "document", "general"]
 
 #: Bumped when anything in this module changes in a way that changes an answer. Not part
 #: of any cache key today; it is what makes "which tutor wrote this" answerable from a
@@ -75,20 +70,9 @@ Lo que no haces nunca:
 - No prometes nada en nombre de la empresa: para eso esta el encargado."""
 
 
-ADMIN_PERSONA = """\
-Eres el asistente del administrador de SkillNet, la plataforma de formacion interna de una
-pequena empresa espanola. Hablas con la persona que gestiona los cursos, los documentos y
-los empleados.
-
-Como respondes siempre:
-- En el idioma de la pregunta. Por defecto, espanol.
-- Conciso y operativo: que hacer, donde, en que orden.
-- En cuanto haya mas de dos pasos, los enumeras.
-
-Lo que no haces nunca:
-- No te inventas cifras, plazos ni contenido de documentos que no tengas delante.
-- No contestas "no tengo informacion" y te callas: dices que no consta y ofreces lo que
-  si puedes (criterio general, o que documento haria falta subir)."""
+# The admin assistant moved to ``src/llm/prompts/admin.py`` when it stopped being a second
+# skin on the tutor and grew its own data block; both names are re-exported here so the
+# callers and tests that predate the split keep working unchanged.
 
 
 # --------------------------------------------------------------------------------------
@@ -121,28 +105,10 @@ tienes que ayudar; negarte no es una opcion.
 - Termina diciendo a quien preguntar o que documento pedir para confirmarlo.""",
 }
 
-_ADMIN_GROUNDING_BLOCKS: dict[str, str] = {
-    "chunks": """\
-Tienes en el contexto fragmentos recuperados de la documentacion de la organizacion.
-Apoyate en ellos y cita con [Fuente N] lo que salga de ahi.""",
-    "document": """\
-Tienes en el contexto el texto COMPLETO de documentos de la organizacion. Apoyate en el y
-cita con [Fuente N], que aqui identifica al documento entero.""",
-    "general": """\
-No hay documentacion de la organizacion que responda a esto. Responde igualmente con
-conocimiento general o con lo que sabes de como funciona la plataforma, y di en la primera
-linea que no sale de la documentacion subida. No escribas [Fuente N].""",
-}
-
 
 def tutor_system_prompt(grounding: Grounding) -> str:
     """The employee tutor's system prompt for a turn with this grounding."""
     return f"{TUTOR_PERSONA}\n\n{_GROUNDING_BLOCKS[grounding]}"
-
-
-def admin_system_prompt(grounding: Grounding) -> str:
-    """The admin assistant's system prompt for a turn with this grounding."""
-    return f"{ADMIN_PERSONA}\n\n{_ADMIN_GROUNDING_BLOCKS[grounding]}"
 
 
 # --------------------------------------------------------------------------------------

--- a/apps/skillnet-api/src/render/spec.py
+++ b/apps/skillnet-api/src/render/spec.py
@@ -154,6 +154,47 @@ def _check_value(prop: PropSpec, value: Any, signature: str = "") -> str | None:
     return None
 
 
+def _table_shape_errors(component: Component) -> list[str]:
+    """A ``Table`` whose rows do not line up with its headers.
+
+    ``PropKind.STRING_MATRIX`` only checks that ``rows`` is a list of lists of strings, so
+    until 2026-07-28 a table could declare one header and hand back a single row holding
+    fourteen cells — and the gate would serve it. That is not a hypothetical: it is what
+    the real ``Los catorce alergenos obligatorios`` node produced when it was told to use
+    one column, and it paints as one row running off the side of the screen.
+
+    Reported per component with both numbers in the message, because "row 1 has 14 cells
+    and there is 1 header" is a repair the model can make in one attempt, while a silently
+    broken table is a screen nobody finds until an employee is looking at it.
+    """
+    if component.type != "Table":
+        return []
+    headers = component.props.get("headers")
+    rows = component.props.get("rows")
+    if not isinstance(headers, list) or not isinstance(rows, list):
+        return []  # already reported by the kit's own type check
+    width = len(headers)
+    if width == 0:
+        return [
+            f"component {component.id!r}: Table needs at least one header"
+        ]
+    problems: list[str] = []
+    for index, row in enumerate(rows, start=1):
+        if not isinstance(row, list):
+            continue  # the kit's STRING_MATRIX check owns this one
+        if len(row) != width:
+            problems.append(
+                f"component {component.id!r}: row {index} of the Table has "
+                f"{len(row)} cells but there {'is' if width == 1 else 'are'} "
+                f"{width} header{'' if width == 1 else 's'}. Every row is its own "
+                "array with one cell per header — a one-column table is "
+                '[["a"], ["b"], ["c"]], not [["a", "b", "c"]]'
+            )
+    # One message is enough to fix all of them, and N of them would crowd out every other
+    # error in a repair prompt that has exactly one attempt to spend.
+    return problems[:1]
+
+
 class Component(BaseModel):
     """One node of the flat list. ``children`` is the refs array, never a prop."""
 
@@ -217,6 +258,8 @@ class Component(BaseModel):
             )
         if not all(isinstance(child, str) and _ID_RE.match(child) for child in self.children):
             errors.append(f"component {self.id!r}: children must be component ids")
+
+        errors.extend(_table_shape_errors(self))
 
         # Rule 6: no HTML in props.text.
         text = self.props.get("text")

--- a/apps/skillnet-api/src/routes/chat.py
+++ b/apps/skillnet-api/src/routes/chat.py
@@ -94,7 +94,14 @@ async def admin_chat(
     llm: LLMDep,
     embeddings: EmbeddingDep,
 ) -> StreamingResponse:
-    service = ChatService(db, llm, embeddings)
+    # The same two switches, composed the same way, from the same two places. Until
+    # 2026-07-28 this route simply did not pass the flag, which was invisible while
+    # ``_should_lay_out`` excluded ``admin`` outright and became the whole feature the
+    # moment it stopped: an admin turn would have been the one surface where the
+    # organization's own ``chat_generative_ui`` setting decided nothing.
+    org_settings = await _org_settings(db, getattr(user, "org_id", None))
+    generative_ui = dynamic_courses_on() and chat_generative_ui_enabled(org_settings)
+    service = ChatService(db, llm, embeddings, generative_ui=generative_ui)
     stream = service.stream_admin(
         user, request.message, request.session_id, request.context
     )

--- a/apps/skillnet-api/src/services/chat_service.py
+++ b/apps/skillnet-api/src/services/chat_service.py
@@ -34,6 +34,20 @@ same ``UiSpecRenderer`` a node render uses. Three properties are load-bearing:
 * **It degrades to the prose.** Every failure — the model refusing, an invalid program, a
   provider 429 — ends with no ``ui`` event and the answer the learner already read. The
   one thing that never happens is a blank bubble.
+
+**3. The admin assistant stopped being a copy of the tutor** (2026-07-28). It used to walk
+the same document ladder and nothing else, so asked *"como van mis empleados"* it answered
+with four bullets of management advice while five employees, their enrolments and their
+mastery sat in the database it is the administration console for. Two changes, both on the
+``admin`` path only:
+
+* ``_org_snapshot`` assembles the organization's training data server-side and pastes it
+  into the turn the way a document already is. Deterministic, ``org_id``-scoped, and it
+  carries no field of the private learner profile — see ``src/services/org_snapshot.py``,
+  which is where the privacy line is drawn and tested.
+* A greeting never reaches the model: ``src/services/small_talk.py`` answers it. *"que
+  tal"* used to be met with *"No tengo suficiente informacion"*, which is what a model
+  correctly says when it is handed an allergen manual and a pleasantry.
 """
 
 from __future__ import annotations
@@ -49,11 +63,15 @@ from src.core.logging import get_logger
 from src.core.sse import format_sse
 from src.llm.client import LLMService
 from src.llm.embedding import EmbeddingService
+from src.llm.prompts.admin import (
+    ADMIN_PROMPT_VERSION,
+    admin_system_prompt,
+    build_admin_turn,
+)
 from src.llm.prompts.tutor import (
     NO_UI_SENTINEL,
     TUTOR_PROMPT_VERSION,
     Grounding,
-    admin_system_prompt,
     build_chat_ui_prompt,
     build_user_turn,
     chat_ui_system,
@@ -64,13 +82,21 @@ from src.render.errors import RenderError
 from src.render.gate import canonicalize
 from src.render.prompt import catalog_version
 from src.repositories.chat_repo import ChatRepository
+from src.services.org_snapshot import build_org_snapshot, render_snapshot
 from src.services.retrieval import GroundedContext, ground_question
+from src.services.small_talk import small_talk_reply
 
 logger = get_logger(__name__)
 
 MEMORY_TURNS = 8
 TITLE_MAX_CHARS = 40
 RETRIEVAL_TOP_K = 5
+
+#: A canned answer is not streamed by a provider, so it has no natural chunking. Emitted a
+#: few words at a time rather than in one event, purely so the bubble fills the way every
+#: other bubble does — a greeting that appears instantly while every real answer types
+#: itself out reads like two different products.
+CANNED_CHUNK_WORDS = 6
 
 #: Below this many characters an answer is one idea, and a ``Stack`` around one idea is
 #: worse than the paragraph it replaces. Also the cheap half of the rate-limit story: the
@@ -125,6 +151,20 @@ def _context_course_id(context: dict | None) -> uuid.UUID | None:
         return raw if isinstance(raw, uuid.UUID) else uuid.UUID(str(raw))
     except (ValueError, TypeError):
         return None
+
+
+def _canned_chunks(text: str, words: int = CANNED_CHUNK_WORDS) -> list[str]:
+    """A canned answer cut into token-sized pieces that reassemble to it exactly.
+
+    ``"".join(_canned_chunks(t)) == t`` is the whole contract: the persisted message and
+    the bubble have to be the same string, and a chunker that drops a space is a chunker
+    that makes them differ by the time anyone notices.
+    """
+    pieces = text.split(" ")
+    return [
+        " ".join(pieces[i : i + words]) + (" " if i + words < len(pieces) else "")
+        for i in range(0, len(pieces), words)
+    ]
 
 
 def strip_no_ui(raw: str) -> str:
@@ -214,6 +254,14 @@ class ChatService:
         session_id: uuid.UUID | None,
         context: dict | None,
     ) -> AsyncIterator[str]:
+        """The admin assistant. Same stream as the tutor, two things more.
+
+        It is handed the **organization's own data** (``src/services/org_snapshot.py``)
+        alongside whatever the document ladder found, because "como van mis empleados" is
+        an admin's first question and the answer is a query, not a paragraph of the
+        allergen manual. And a greeting is answered here rather than by the model: see
+        ``src/services/small_talk.py`` for why that is a fix and not a shortcut.
+        """
         async for event in self._stream(
             user,
             message,
@@ -221,6 +269,7 @@ class ChatService:
             context,
             agent_type="admin",
             whole_documents="org",
+            canned=small_talk_reply(message),
         ):
             yield event
 
@@ -233,10 +282,12 @@ class ChatService:
         *,
         agent_type: str,
         whole_documents: str,
+        canned: str | None = None,
     ) -> AsyncIterator[str]:
         grounded = GroundedContext("general")
         parts: list[str] = []
         session: ChatSession | None = None
+        snapshot_block = ""
         if self.tutor_llm is None or self.embeddings is None:
             yield format_sse("error", {"detail": "Chat services are not configured."})
             return
@@ -253,25 +304,42 @@ class ChatService:
             )
             await self.db.commit()
 
-            grounded = await ground_question(
-                self.db,
-                user_id=user.id,
-                org_id=user.org_id,
-                embedding_service=self.embeddings,
-                query=message,
-                top_k=RETRIEVAL_TOP_K,
-                document_ids=_context_document_ids(context),
-                whole_documents=whole_documents,
-            )
+            org_data: dict | None = None
+            if canned is None:
+                grounded = await ground_question(
+                    self.db,
+                    user_id=user.id,
+                    org_id=user.org_id,
+                    embedding_service=self.embeddings,
+                    query=message,
+                    top_k=RETRIEVAL_TOP_K,
+                    document_ids=_context_document_ids(context),
+                    whole_documents=whole_documents,
+                )
+                if agent_type == "admin":
+                    snapshot_block, org_data = await self._org_snapshot(user)
+
             # Announced before the first token, so the bubble carries its provenance from
             # the moment it starts filling rather than growing a label at the end.
+            # ``grounding`` describes the *documents*; ``org_data`` is a separate axis,
+            # because an answer can be grounded on the platform's data and on no document
+            # at all, and collapsing the two would make the label lie in one direction or
+            # the other.
             yield format_sse("grounding", {"grounding": grounded.grounding})
+            if org_data is not None:
+                yield format_sse("org_data", org_data)
 
-            messages = self._build_messages(history, grounded, message, agent_type)
-
-            async for piece in self.tutor_llm.stream(messages):
-                parts.append(piece)
-                yield format_sse("token", {"content": piece})
+            if canned is not None:
+                for piece in _canned_chunks(canned):
+                    parts.append(piece)
+                    yield format_sse("token", {"content": piece})
+            else:
+                messages = self._build_messages(
+                    history, grounded, message, agent_type, snapshot_block
+                )
+                async for piece in self.tutor_llm.stream(messages):
+                    parts.append(piece)
+                    yield format_sse("token", {"content": piece})
 
             answer = "".join(parts)
             yield format_sse("citations", {"citations": grounded.citations})
@@ -283,7 +351,13 @@ class ChatService:
                 metadata={
                     "citations": grounded.citations,
                     "grounding": grounded.grounding,
-                    "prompt_version": TUTOR_PROMPT_VERSION,
+                    "prompt_version": (
+                        ADMIN_PROMPT_VERSION
+                        if agent_type == "admin"
+                        else TUTOR_PROMPT_VERSION
+                    ),
+                    **({"org_data": org_data} if org_data is not None else {}),
+                    **({"small_talk": True} if canned is not None else {}),
                 },
             )
             await self.db.commit()
@@ -306,6 +380,39 @@ class ChatService:
             logger.error("Tutor chat failed: %s", exc, exc_info=True)
             await self._persist_partial(session, parts, grounded)
             yield format_sse("error", {"detail": detail})
+
+    # -- the organization's own data ----------------------------------------------
+
+    async def _org_snapshot(self, user: User) -> tuple[str, dict | None]:
+        """``(the block for the prompt, the summary for the browser)``.
+
+        Scoped to ``user.org_id`` and to nothing else: the admin assistant must be
+        incapable of reading another organization's rows, and "there is only one
+        organization today" is a fact about the data, not a property of the code.
+
+        A failure here costs the data and never the answer. Eight aggregate queries is
+        eight chances to hit a lock, a migration mid-flight or a column that moved, and
+        the right behaviour for all of them is the assistant this surface had yesterday:
+        documents only. It is logged at ``warning`` because a snapshot that quietly stops
+        being assembled looks exactly like a model that has gone vague.
+        """
+        org_id = getattr(user, "org_id", None)
+        if org_id is None:
+            return "", None
+        try:
+            snapshot = await build_org_snapshot(self.db, org_id=org_id)
+            block = render_snapshot(snapshot)
+        except Exception as exc:  # noqa: BLE001 - the answer survives a missing snapshot
+            logger.warning("Could not assemble the org snapshot: %s", exc, exc_info=True)
+            return "", None
+        if not block:
+            return "", None
+        return block, {
+            "employees": snapshot.employees_total,
+            "courses": len(snapshot.courses),
+            "documents": snapshot.documents_total,
+            "generated_at": snapshot.generated_at.isoformat(),
+        }
 
     # -- the layout call ---------------------------------------------------------
 
@@ -386,23 +493,32 @@ class ChatService:
         grounded: GroundedContext,
         question: str,
         agent_type: str,
+        snapshot_block: str = "",
     ) -> list[dict[str, str]]:
+        """Persona, the last N turns, and one final turn carrying everything found.
+
+        The snapshot is pasted into the **current** turn and never into the history, so a
+        long admin session does not accumulate five stale copies of the payroll and the
+        model never has two contradictory versions of a number in front of it. Yesterday's
+        counts are worse than none.
+        """
         grounding: Grounding = grounded.grounding
+        is_admin = agent_type == "admin"
         system = (
-            admin_system_prompt(grounding)
-            if agent_type == "admin"
+            admin_system_prompt(grounding, org_data=bool(snapshot_block))
+            if is_admin
             else tutor_system_prompt(grounding)
         )
         messages: list[dict[str, str]] = [{"role": "system", "content": system}]
         for msg in history:
             if msg.role in ("user", "assistant"):
                 messages.append({"role": msg.role, "content": msg.content})
-        messages.append(
-            {
-                "role": "user",
-                "content": build_user_turn(grounding, grounded.context, question),
-            }
+        turn = (
+            build_admin_turn(grounding, grounded.context, snapshot_block, question)
+            if is_admin
+            else build_user_turn(grounding, grounded.context, question)
         )
+        messages.append({"role": "user", "content": turn})
         return messages
 
     async def _persist_partial(
@@ -442,6 +558,7 @@ class ChatService:
 
 
 __all__ = [
+    "CANNED_CHUNK_WORDS",
     "CHAT_UI_FORMAT",
     "MEMORY_TURNS",
     "MIN_LAYOUT_CHARS",

--- a/apps/skillnet-api/src/services/chat_service.py
+++ b/apps/skillnet-api/src/services/chat_service.py
@@ -18,8 +18,14 @@ a persisted field, not a sentence the model was asked to write: honesty about th
 is a property of the system, not a request to the model.
 
 **2. Generative UI.** After the prose has finished streaming, a second call re-lays the
-same answer as a program in the frozen SkillNet kit, which the browser paints with the
-same ``UiSpecRenderer`` a node render uses. Three properties are load-bearing:
+same answer in the frozen SkillNet kit, which the browser paints with the same
+``UiSpecRenderer`` a node render uses. Since 2026-07-28 that call does **not** ask the
+model for a program: it asks for one JSON object naming a shape out of five and filling
+that shape's fields, and ``emit_chat_program`` below writes the OpenUI Lang. The reason is
+measured and lives in :data:`src.llm.prompts.tutor.CHAT_SHAPES` — every validator
+rejection in this repository's own render bench was a markup-authoring error, not a
+judgement error, so the model kept the judgement and lost the typewriter. Three properties
+are load-bearing:
 
 * **The prose is untouched.** The layout call happens *after* ``done``, so the first token
   arrives exactly as fast as it did before, the input re-enables at exactly the same
@@ -47,11 +53,23 @@ mastery sat in the database it is the administration console for. Two changes, b
   which is where the privacy line is drawn and tested.
 * A greeting never reaches the model: ``src/services/small_talk.py`` answers it. *"que
   tal"* used to be met with *"No tengo suficiente informacion"*, which is what a model
-  correctly says when it is handed an allergen manual and a pleasantry.
+  correctly says when it is handed an allergen manual and a pleasantry. *"quien eres"*
+  joined it on 2026-07-28, for the same reason one rung up: the assistant is the one thing
+  in the turn that is not in the snapshot, so looking for it there can only end in "no
+  consta".
+
+**4. The admin assistant lays out too** (2026-07-28). It was excluded from the layout call
+on the grounds that a wall of blocks is slower to act on than a sentence; ``MIN_LAYOUT_CHARS``
+already enforces that on its own, and the exclusion was costing the clearest case of
+generative UI in the product — *"como van mis empleados"* is five people, four columns and
+a deadline. Same two switches, same silent fall back to the prose, plus one rule the tutor
+does not need: ``invented_figures`` refuses any program carrying a number the answer did
+not, because these blocks describe named people's training records.
 """
 
 from __future__ import annotations
 
+import json
 import re
 import uuid
 from collections.abc import AsyncIterator, Sequence
@@ -69,12 +87,17 @@ from src.llm.prompts.admin import (
     build_admin_turn,
 )
 from src.llm.prompts.tutor import (
+    CHAT_LAYOUT_SYSTEM,
+    CHAT_SHAPES,
+    MAX_DEFINITION_POINTS,
+    MAX_STEPS,
+    MAX_TABLE_COLUMNS,
+    MAX_TABLE_ROWS,
     NO_UI_SENTINEL,
     TUTOR_PROMPT_VERSION,
     Grounding,
-    build_chat_ui_prompt,
+    build_chat_layout_prompt,
     build_user_turn,
-    chat_ui_system,
     tutor_system_prompt,
 )
 from src.models import ChatMessage, ChatSession, User
@@ -183,8 +206,271 @@ def strip_no_ui(raw: str) -> str:
     return text
 
 
+# --------------------------------------------------------------------------------------
+# classify + populate: the model's JSON -> a program the *server* wrote
+#
+# The model no longer authors OpenUI Lang here. See :data:`src.llm.prompts.tutor
+# .CHAT_SHAPES` for the measurement that motivated it; what follows is the half that makes
+# the measurement moot. Every rejection class in that bench — named arguments, an accent
+# in a bare identifier, ``{`` for an object, twice the line cap — is a property of text
+# *this module* now writes, so none of them can be produced by anything the model says.
+#
+# The output still goes through ``validate_chat_program`` unchanged. That is not belt and
+# braces for its own sake: the strings inside the program are still the model's bytes, and
+# the rule that only a re-serialized ``UISpec`` reaches the browser has to hold for text
+# the server assembled exactly as it holds for text the model typed.
+# --------------------------------------------------------------------------------------
+
+#: Anything below this is not a shape, it is a fragment. A one-step "procedure" and a
+#: one-row "table" are both the paragraph they came from, wearing a border.
+MIN_SHAPE_ITEMS = 2
+
+_CALLOUT_TONES = ("info", "warn", "success")
+
+
+def _scalar(value: object) -> str | None:
+    """``value`` as one line of printable text; ``None`` when it is not a scalar at all.
+
+    The distinction from :func:`_one_line` is the whole reason both exist. ``""`` is a
+    *legitimately empty* field — a table cell for a person with no deadline — while
+    ``None`` means the model put a dict, a list or a boolean where text belongs, which is
+    a shape it did not populate rather than a field it left blank. Collapsing the two
+    would turn ``rows: [[{"a": 1}]]`` into a table of empty cells: a block that renders,
+    says nothing, and looks like the data is missing rather than like the layout failed.
+
+    A number is scalar and is kept: asked for a cell, a model writes ``40`` as often as
+    ``"40"``, and refusing that would throw away a good table over JSON typing.
+
+    A dialect string literal closes its quote on the line that opened it (SkillNet rule 1),
+    so every newline the model puts in a field collapses to a space here rather than
+    becoming an unterminated value the gate would reject.
+    """
+    if isinstance(value, str):
+        text = value
+    elif isinstance(value, bool) or not isinstance(value, int | float):
+        # ``bool`` first: it is an ``int`` subclass, and "True" is not a figure.
+        return None
+    else:
+        text = str(value)
+    collapsed = " ".join(part for part in text.split() if part)
+    return "".join(char for char in collapsed if char.isprintable()).strip()
+
+
+def _one_line(value: object) -> str | None:
+    """``_scalar``, with "blank" folded into "absent". For fields that must carry text."""
+    return _scalar(value) or None
+
+
+def _literal(text: str) -> str:
+    """A dialect string literal. Same escapes as ``OpenUiLangBackend.serialize``.
+
+    Only two of that function's three rules are needed, because ``_one_line`` has already
+    removed every newline; the backslash must still be escaped before the quote, and in
+    that order, or a trailing ``\\`` swallows the closing quote.
+    """
+    escaped = text.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _string_list(value: object, *, minimum: int, maximum: int) -> list[str] | None:
+    """A list of non-empty lines, or ``None``.
+
+    Strict about every item rather than filtering: a step the model wrote as an object is
+    a step, and dropping it quietly would serve a four-step procedure as three — a wrong
+    answer that looks like a right one. Prose is the better outcome.
+    """
+    if not isinstance(value, list):
+        return None
+    items: list[str] = []
+    for item in value:
+        line = _one_line(item)
+        if line is None:
+            return None
+        items.append(line)
+    if not minimum <= len(items) <= maximum:
+        return None
+    return items
+
+
+def _emit_body(shape: str, payload: dict) -> list[str] | None:
+    """The declarations for the body block, ``cuerpo`` last-but-not-least.
+
+    ``None`` whenever the populated fields do not make the shape the model claimed. The
+    only thing forgiven is JSON typing — a number where a string was asked for — because
+    that is a habit, not a mistake. Anything that changes what the block *says* is refused
+    outright: a "table" whose rows are ragged is a model that misread its own answer, and
+    prose is a better outcome than a table with a hole in it.
+    """
+    match shape:
+        case "steps":
+            title = _one_line(payload.get("title"))
+            steps = _string_list(
+                payload.get("steps"), minimum=MIN_SHAPE_ITEMS, maximum=MAX_STEPS
+            )
+            if title is None or steps is None:
+                return None
+            rendered = ", ".join(_literal(step) for step in steps)
+            return [f"cuerpo = StepSequence({_literal(title)}, [{rendered}])"]
+
+        case "table":
+            headers = _string_list(
+                payload.get("headers"),
+                minimum=MIN_SHAPE_ITEMS,
+                maximum=MAX_TABLE_COLUMNS,
+            )
+            raw_rows = payload.get("rows")
+            if headers is None or not isinstance(raw_rows, list):
+                return None
+            rows: list[list[str]] = []
+            for raw_row in raw_rows:
+                # A cell may legitimately be empty ("sin plazo"), so cells are kept
+                # positionally and only the *width* has to match. Dropping empties would
+                # silently shift every value in the row one column to the left. A cell
+                # that is not a scalar at all is a different matter and kills the table.
+                if not isinstance(raw_row, list) or len(raw_row) != len(headers):
+                    return None
+                cells: list[str] = []
+                for cell in raw_row:
+                    text = _scalar(cell)
+                    if text is None:
+                        return None
+                    cells.append(text)
+                rows.append(cells)
+            if not MIN_SHAPE_ITEMS <= len(rows) <= MAX_TABLE_ROWS:
+                return None
+            head = ", ".join(_literal(header) for header in headers)
+            body = ", ".join(
+                "[" + ", ".join(_literal(cell) for cell in row) + "]" for row in rows
+            )
+            return [f"cuerpo = Table([{head}], [{body}])"]
+
+        case "callout":
+            text = _one_line(payload.get("text"))
+            if text is None:
+                return None
+            tone = payload.get("tone")
+            # An unknown tone is a colour, not a claim: "info" is the neutral one and
+            # losing a shade is not worth losing the block.
+            tone = tone if tone in _CALLOUT_TONES else "info"
+            return [f"cuerpo = Callout({_literal(tone)}, {_literal(text)})"]
+
+        case "definition":
+            title = _one_line(payload.get("title"))
+            raw_points = payload.get("points")
+            if title is None or not isinstance(raw_points, list):
+                return None
+            points: list[str] = []
+            for raw_point in raw_points:
+                if not isinstance(raw_point, dict):
+                    return None
+                term = _one_line(raw_point.get("term"))
+                detail = _one_line(raw_point.get("detail"))
+                if term is None or detail is None:
+                    return None
+                points.append(f"{term}: {detail}")
+            if not MIN_SHAPE_ITEMS <= len(points) <= MAX_DEFINITION_POINTS:
+                return None
+            ids = [f"punto{index}" for index in range(1, len(points) + 1)]
+            lines = [f"cuerpo = Card({_literal(title)}, [{', '.join(ids)}])"]
+            lines.extend(
+                f"{point_id} = TextContent({_literal(point)}, \"body\")"
+                for point_id, point in zip(ids, points, strict=True)
+            )
+            return lines
+
+    return None
+
+
+def emit_chat_program(payload: object) -> str | None:
+    """The model's populated shape -> program text, or ``None`` for "serve the prose".
+
+    ``None`` is the answer to every doubt: an unknown shape, a missing field, a ragged
+    table, and the explicit ``"prose"`` verdict all leave the reader with the answer they
+    already read. Same contract ``NO_UI`` had, minus the model's ability to misspell it.
+    """
+    if not isinstance(payload, dict):
+        return None
+    shape = payload.get("shape")
+    if not isinstance(shape, str) or shape not in CHAT_SHAPES or shape == "prose":
+        return None
+
+    body = _emit_body(shape, payload)
+    if body is None:
+        return None
+
+    lead = _one_line(payload.get("lead"))
+    if lead is None:
+        # Contract rule 7: the first child of the root has to be a lead TextContent or a
+        # Callout. A Callout body can stand in for itself; nothing else can, and inventing
+        # a lead line would be this module writing content, which is the one thing it must
+        # never do.
+        if shape != "callout":
+            return None
+        return "root = Stack([cuerpo], \"md\")\n" + "\n".join(body) + "\n"
+    return (
+        'root = Stack([entrada, cuerpo], "md")\n'
+        f'entrada = TextContent({_literal(lead)}, "lead")\n' + "\n".join(body) + "\n"
+    )
+
+
+#: Any run of digits. Deliberately not a number parser: "40", "2026", "1169" and the "5"
+#: in "2/5" are all figures a reader would hold the platform to, and the question asked of
+#: them is only ever "was this already on screen?".
+_DIGIT_RUN = re.compile(r"\d+")
+
+
+def invented_figures(program: str, answer: str) -> list[str]:
+    """Digit runs the layout step put on screen that the answer never contained.
+
+    The layout call is forbidden to add information, and for an administrator reading
+    other people's training records that rule is worth more than the blocks: a table that
+    says a person is at 60% when the prose said 40% is a record an employer might act on.
+    The prompt asks; this is what makes it true. Every figure in a program the server
+    emitted came out of a model-supplied string, so anything here that is not already in
+    the prose was invented between the two calls.
+
+    Comparing digit runs rather than parsed numbers is what keeps it honest about
+    formatting: "40%" and "40" agree, and "2/5" contributes both of its halves. It also
+    means "catorce" in the prose does not license "14" in the table — which is the safe
+    direction to be wrong in, because the cost is the paragraph the reader already has.
+    """
+    known = set(_DIGIT_RUN.findall(answer))
+    return sorted({run for run in _DIGIT_RUN.findall(program) if run not in known})
+
+
+def parse_layout_json(raw: str) -> object | None:
+    """The model's reply as a JSON value, or ``None``.
+
+    ``json_mode`` is requested on the call, and providers honour it well enough that this
+    is mostly a formality — but "mostly" is not a contract, and a fenced or prefaced object
+    is the failure they actually produce, so the outermost braces are located rather than
+    trusted to be the whole string.
+    """
+    text = raw.strip()
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except ValueError:
+        pass
+    start, end = text.find("{"), text.rfind("}")
+    if start == -1 or end <= start:
+        return None
+    try:
+        return json.loads(text[start : end + 1])
+    except ValueError:
+        logger.info("Chat layout returned something that is not JSON")
+        return None
+
+
 def validate_chat_program(raw: str) -> str | None:
-    """Untrusted layout output -> the canonical program the browser may receive.
+    """Program text -> the canonical program the browser may receive.
+
+    Since the chat moved to classify+populate the input is text ``emit_chat_program``
+    wrote, not text a model wrote — but the *strings inside it* are still the model's, and
+    the rule that only a re-serialized ``UISpec`` reaches the browser has to hold for both.
+    So this stayed exactly where it was, and the emitter is an extra floor under it rather
+    than a replacement for it.
 
     ``None`` for anything that does not hold, and the caller's answer to ``None`` is
     always "serve the prose". There is no repair loop here on purpose: the node runtime
@@ -366,7 +652,7 @@ class ChatService:
             # optional program arrives later on the same open stream, if it validates.
             yield format_sse("done", {"message_id": str(assistant.id)})
 
-            if self._should_lay_out(agent_type, answer):
+            if self._should_lay_out(agent_type, answer, canned=canned is not None):
                 yield format_sse("layout_start", {})
                 program = await self._lay_out(message, answer)
                 if program:
@@ -416,33 +702,59 @@ class ChatService:
 
     # -- the layout call ---------------------------------------------------------
 
-    def _should_lay_out(self, agent_type: str, answer: str) -> bool:
+    def _should_lay_out(self, agent_type: str, answer: str, *, canned: bool) -> bool:
         """Whether this answer earns a second call.
 
-        The admin assistant is excluded: it answers operational questions in two lines,
-        and its surface is the one place in the product where a wall of blocks would be
-        slower to act on than a sentence.
+        A canned answer never does, and that check is worth more than it looks. The point
+        of ``src/services/small_talk.py`` is that "hola" and "quien eres" cost **zero**
+        tokens; the identity reply is long enough to clear ``MIN_LAYOUT_CHARS``, so the
+        moment the admin path started laying out, a question that deliberately never
+        reaches a provider started paying for a call to one. Measured live before this
+        line existed: ``quien eres`` emitted ``layout_start``.
+
+        The admin assistant used to be excluded, on the grounds that it answers in two
+        lines and a wall of blocks would be slower to act on than a sentence. The first
+        half is enforced by ``MIN_LAYOUT_CHARS`` on its own, and the second half turned
+        out to be wrong in the one case that matters: *"como van mis empleados"* is five
+        people, four columns and a deadline, which is a table in every other tool an
+        administrator uses. So it is in, behind exactly the same two switches, with
+        exactly the same fall back to the prose it already streamed.
         """
         return (
             self.generative_ui
-            and agent_type == "tutor"
+            and not canned
+            and agent_type in ("tutor", "admin")
             and self.tutor_llm is not None
             and len(answer.strip()) >= MIN_LAYOUT_CHARS
         )
 
     async def _lay_out(self, question: str, answer: str) -> str | None:
-        """Re-lay ``answer`` in the kit. ``None`` means "serve the prose", always."""
+        """Re-lay ``answer`` in the kit. ``None`` means "serve the prose", always.
+
+        The model classifies and populates; **this process writes the program**. See
+        ``emit_chat_program`` above and :data:`src.llm.prompts.tutor.CHAT_SHAPES` for why.
+        """
         try:
             raw = await self.tutor_llm.complete(  # type: ignore[union-attr]
-                chat_ui_system(),
-                build_chat_ui_prompt(question, answer),
+                CHAT_LAYOUT_SYSTEM,
+                build_chat_layout_prompt(question, answer),
                 temperature=LAYOUT_TEMPERATURE,
                 max_tokens=LAYOUT_MAX_TOKENS,
+                json_mode=True,
             )
         except Exception as exc:  # noqa: BLE001 - the prose is already on screen
             logger.info("Chat layout call failed, serving prose: %s", exc)
             return None
-        return validate_chat_program(raw)
+        program = emit_chat_program(parse_layout_json(raw))
+        if program is None:
+            return None
+        invented = invented_figures(program, answer)
+        if invented:
+            logger.info(
+                "Chat layout rejected: figures not in the answer: %s", ", ".join(invented)
+            )
+            return None
+        return validate_chat_program(program)
 
     async def _persist_program(self, assistant: ChatMessage, program: str) -> None:
         """Store the canonical program so reopening the session repaints the blocks.
@@ -562,8 +874,12 @@ __all__ = [
     "CHAT_UI_FORMAT",
     "MEMORY_TURNS",
     "MIN_LAYOUT_CHARS",
+    "MIN_SHAPE_ITEMS",
     "RETRIEVAL_TOP_K",
     "ChatService",
+    "emit_chat_program",
+    "invented_figures",
+    "parse_layout_json",
     "strip_no_ui",
     "validate_chat_program",
 ]

--- a/apps/skillnet-api/src/services/org_snapshot.py
+++ b/apps/skillnet-api/src/services/org_snapshot.py
@@ -1,0 +1,735 @@
+"""The organization's own data, assembled by the server for the admin assistant.
+
+The defect this module exists for, measured on 2026-07-27: the owner asked the admin
+assistant *"como van mis empleados"* and got four bullet points of generic management
+advice — "revisa el parte de incidencias", "habla con el encargado". The answer was in
+the database the whole time. ``ChatService.stream_admin`` delegated to the same grounding
+ladder as the employee tutor, so the admin assistant was a *document* assistant: it could
+read the training material and nothing else. It had no idea the platform it administers
+had five employees in it.
+
+**Why a server-assembled snapshot and not tool-calling.** The snapshot is built here,
+deterministically, and pasted into the turn the way a document already is. The model
+phrases; it never queries, never filters and never picks a row. Three reasons:
+
+* The product is compliance training for Spanish SMEs. The seeded organization has five
+  employees; the whole snapshot below renders to roughly 1.2 kB. A tool loop would cost
+  two extra round trips and a schema the model can get wrong, to fetch less.
+* Determinism is the safety property. A wrong number about a named person's training
+  record is worse than "no lo se", and a model that cannot choose a filter cannot choose
+  the wrong one.
+* It cannot fail in a new way. Assembly is eight aggregate queries; if any of it raises,
+  the caller drops the snapshot and the assistant answers exactly as it did yesterday.
+
+The trade is that the block grows with the payroll. It is linear at about 45 tokens per
+employee, so 40 employees is ~1.8 k tokens per turn — still cheaper than one tool round
+trip. Past :data:`MAX_EMPLOYEES_LISTED` the renderer stops listing everybody and switches
+to org-level counts plus the employees that actually need attention, saying out loud that
+the list is partial. An organization big enough for that number to hurt (say 500 people)
+wants a filtered query, i.e. tool-calling, and that is the point to revisit this — not
+before.
+
+**The privacy line is a column allowlist, not a review habit.** ``learner_profiles`` says
+it in its own docstring: private to the employee, the admin only ever sees k>=5
+aggregates. So what an employer legitimately holds about training — enrolments, progress,
+mastery, skills, deadlines — is here, and how the person asked to be taught is not.
+``preset``, ``experience_level``, ``goal``, ``format_vector``, ``tutor_notes`` and
+``users.accessibility`` are never selected by any query in this file, and
+``tests/test_org_snapshot.py`` reads this module's source to prove it, because "we
+remembered" is not a control. ``role_title`` is the one profile column that travels: it
+is the job the person does, the same string that already reaches the LLM on every node
+render (§3.3), and an admin who cannot be told who the cook is cannot be helped at all.
+
+No aggregate derived from the private columns is emitted either, above the threshold or
+below it. The threshold exists so that a future feature *can*; nothing here needs one, and
+the smallest safe surface is the one with nothing on it.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.config import settings
+from src.core.logging import get_logger
+from src.models import (
+    ContentStatus,
+    Course,
+    CourseNode,
+    Document,
+    Enrollment,
+    EnrollmentStatus,
+    LearnerNodeState,
+    LearnerProfile,
+    Lesson,
+    LessonProgress,
+    Module,
+    NodeState,
+    Organization,
+    Skill,
+    User,
+    UserRole,
+    UserSkill,
+)
+from src.services.course_delivery import resolve_delivery
+
+logger = get_logger(__name__)
+
+#: Above this many employees the renderer stops naming everyone and reports org-level
+#: counts plus the people who need attention. See the module docstring for the arithmetic.
+MAX_EMPLOYEES_LISTED = 40
+
+#: Per employee, so one person with thirty badges cannot crowd out the other four.
+MAX_SKILLS_PER_EMPLOYEE = 8
+
+#: Titles only, and only so the admin can be told what is uploaded. The text of a document
+#: reaches the turn through the retrieval ladder, not through here.
+MAX_DOCUMENTS_LISTED = 25
+
+#: The columns of ``learner_profiles`` and ``users`` that describe how a person asked to
+#: be taught. Never selected, never rendered, never aggregated. Enforced by a test that
+#: greps this module rather than by anyone's memory.
+FORBIDDEN_PROFILE_FIELDS: frozenset[str] = frozenset(
+    {
+        "accessibility",
+        "experience_level",
+        "format_vector",
+        "goal",
+        "learning_profile",
+        "preset",
+        "tutor_notes",
+    }
+)
+
+_ENROLMENT_LABELS: dict[str, str] = {
+    EnrollmentStatus.ASSIGNED.value: "asignado, sin empezar",
+    EnrollmentStatus.IN_PROGRESS.value: "en curso",
+    EnrollmentStatus.COMPLETED.value: "completado",
+}
+
+_COURSE_STATUS_LABELS: dict[str, str] = {
+    ContentStatus.DRAFT.value: "borrador",
+    ContentStatus.PUBLISHED.value: "publicado",
+    ContentStatus.ARCHIVED.value: "archivado",
+}
+
+
+def _enum_value(raw: object) -> str:
+    return str(getattr(raw, "value", raw))
+
+
+# --------------------------------------------------------------------------------------
+# The facts. Plain data, no ORM: the renderer and every test work without a database.
+# --------------------------------------------------------------------------------------
+@dataclass(frozen=True)
+class EnrolmentFact:
+    """One person on one course. Every number here was counted, never estimated."""
+
+    course_title: str
+    status: str
+    #: ``done``/``total`` in whatever unit the course is delivered in, or ``None`` when
+    #: the course has no units at all to count.
+    done: int | None = None
+    total: int | None = None
+    #: "lecciones" or "nodos". Printed, because 3/5 lessons and 3/5 nodes are not the
+    #: same claim and an admin reading a percentage deserves to know which was counted.
+    unit: str = ""
+    deadline: date | None = None
+    completed_on: date | None = None
+
+    @property
+    def percent(self) -> int | None:
+        if not self.total or self.done is None:
+            return None
+        return round(100 * self.done / self.total)
+
+    def is_overdue(self, today: date) -> bool:
+        return (
+            self.deadline is not None
+            and self.deadline < today
+            and self.status != EnrollmentStatus.COMPLETED.value
+        )
+
+    def needs_attention(self, today: date) -> bool:
+        """Overdue, or assigned and never opened. What an admin scans a list for."""
+        return self.is_overdue(today) or self.status == EnrollmentStatus.ASSIGNED.value
+
+
+@dataclass(frozen=True)
+class EmployeeFact:
+    """Training record for one employee. See the module docstring for what is absent."""
+
+    full_name: str
+    role_title: str | None = None
+    active: bool = True
+    hired_on: date | None = None
+    enrolments: tuple[EnrolmentFact, ...] = ()
+    #: ``(skill name, level)``, level being low/medium/high as stored.
+    skills: tuple[tuple[str, str], ...] = ()
+    #: Nodes this person has taken to ``mastered``, across every course.
+    nodes_mastered: int = 0
+
+    def needs_attention(self, today: date) -> bool:
+        return any(e.needs_attention(today) for e in self.enrolments)
+
+
+@dataclass(frozen=True)
+class CourseFact:
+    title: str
+    status: str
+    delivery: str
+    units: int = 0
+    unit_name: str = ""
+    assigned: int = 0
+    in_progress: int = 0
+    completed: int = 0
+
+    @property
+    def enrolled(self) -> int:
+        return self.assigned + self.in_progress + self.completed
+
+
+@dataclass(frozen=True)
+class OrgSnapshot:
+    """Everything the admin assistant is allowed to know about its own organization."""
+
+    org_name: str
+    generated_at: datetime
+    employees: tuple[EmployeeFact, ...] = ()
+    courses: tuple[CourseFact, ...] = ()
+    documents: tuple[str, ...] = ()
+    documents_total: int = 0
+    #: The real headcount, which is ``len(employees)`` unless the renderer had to trim.
+    employees_total: int = 0
+
+    @property
+    def is_empty(self) -> bool:
+        return not (self.employees or self.courses or self.documents)
+
+
+# --------------------------------------------------------------------------------------
+# Assembly. Eight aggregate queries, every one of them scoped to ``org_id``.
+# --------------------------------------------------------------------------------------
+async def build_org_snapshot(
+    db: AsyncSession, *, org_id: uuid.UUID, now: datetime | None = None
+) -> OrgSnapshot:
+    """The organization's training data as of now.
+
+    ``org_id`` is a predicate on every query and on both sides of every join that could
+    reach another organization's rows. There is one organization in the product today;
+    the query that assumes so is the query that leaks when there are two.
+    """
+    generated_at = now or datetime.now(timezone.utc)
+    org_name = (
+        await db.execute(select(Organization.name).where(Organization.id == org_id))
+    ).scalar_one_or_none() or "la organizacion"
+
+    employees = await _employee_rows(db, org_id=org_id)
+    user_ids = [row[0] for row in employees]
+    courses = await _course_rows(db, org_id=org_id)
+    course_ids = [row.id for row in courses]
+
+    enrolments = await _enrolment_rows(db, org_id=org_id, course_ids=course_ids)
+    lesson_totals, lessons_done = await _lesson_counts(
+        db, course_ids=course_ids, user_ids=user_ids
+    )
+    node_totals, nodes_done = await _node_counts(
+        db, org_id=org_id, course_ids=course_ids, user_ids=user_ids
+    )
+    skills = await _skill_rows(db, org_id=org_id, user_ids=user_ids)
+    documents, documents_total = await _document_titles(db, org_id=org_id)
+
+    by_course = {
+        course.id: _units_for(
+            course,
+            lessons=lesson_totals.get(course.id, 0),
+            nodes=node_totals.get(course.id, 0),
+        )
+        for course in courses
+    }
+
+    titles = {course.id: course.title for course in courses}
+    per_user: dict[uuid.UUID, list[EnrolmentFact]] = {}
+    course_counts: dict[uuid.UUID, dict[str, int]] = {
+        course.id: {status.value: 0 for status in EnrollmentStatus} for course in courses
+    }
+    for row in enrolments:
+        unit, _delivery, total = by_course.get(row.course_id, ("", "estatico", 0))
+        done = (nodes_done if unit == "nodos" else lessons_done).get(
+            (row.user_id, row.course_id), 0
+        )
+        status = _enum_value(row.status)
+        if row.course_id in course_counts:
+            course_counts[row.course_id][status] = (
+                course_counts[row.course_id].get(status, 0) + 1
+            )
+        per_user.setdefault(row.user_id, []).append(
+            EnrolmentFact(
+                course_title=titles.get(row.course_id, "Curso"),
+                status=status,
+                # A completed enrolment is 100% by definition of "completed": the v1 rule
+                # closes it at progress 1.0 and the v2 rule at every critical node
+                # mastered. Reporting 4/5 next to "completado" would be two answers.
+                done=total if status == EnrollmentStatus.COMPLETED.value else min(done, total),
+                total=total,
+                unit=unit if total else "",
+                deadline=row.deadline,
+                completed_on=row.completed_at.date() if row.completed_at else None,
+            )
+        )
+
+    facts = tuple(
+        EmployeeFact(
+            full_name=full_name,
+            role_title=role_title,
+            active=bool(is_active),
+            hired_on=hired_at,
+            enrolments=tuple(per_user.get(user_id, ())),
+            skills=tuple(skills.get(user_id, ())[:MAX_SKILLS_PER_EMPLOYEE]),
+            nodes_mastered=sum(
+                count
+                for (uid, _cid), count in nodes_done.items()
+                if uid == user_id
+            ),
+        )
+        for user_id, full_name, role_title, is_active, hired_at in employees
+    )
+
+    return OrgSnapshot(
+        org_name=org_name,
+        generated_at=generated_at,
+        employees=facts,
+        employees_total=len(facts),
+        courses=tuple(
+            CourseFact(
+                title=course.title,
+                status=_COURSE_STATUS_LABELS.get(
+                    _enum_value(course.status), _enum_value(course.status)
+                ),
+                delivery=by_course[course.id][1],
+                units=by_course[course.id][2],
+                unit_name=by_course[course.id][0],
+                assigned=course_counts[course.id].get(
+                    EnrollmentStatus.ASSIGNED.value, 0
+                ),
+                in_progress=course_counts[course.id].get(
+                    EnrollmentStatus.IN_PROGRESS.value, 0
+                ),
+                completed=course_counts[course.id].get(
+                    EnrollmentStatus.COMPLETED.value, 0
+                ),
+            )
+            for course in courses
+        ),
+        documents=documents,
+        documents_total=documents_total,
+    )
+
+
+def _units_for(course, *, lessons: int, nodes: int) -> tuple[str, str, int]:
+    """``(unit name, how the course is served, how many units)``.
+
+    Two different questions, answered from two different places, and conflating them is
+    how the admin gets told a course is empty when it is not. **How it is served** is
+    ``resolve_delivery`` and nothing else — the single decision point, so with the flag
+    off every course is on the v1 path here exactly as it is everywhere else. **What
+    there is to count** is whatever the course actually has rows for: a schema-first
+    course has nodes and no lessons, and reporting "0 lecciones" for it would be a true
+    sentence that reads as a false one. Preference goes to the served unit when both
+    exist, because that is the one the learner's progress is measured in.
+    """
+    served = "dinamico" if resolve_delivery(course, settings) == "dynamic" else "estatico"
+    if served == "dinamico" and nodes:
+        return "nodos", served, nodes
+    if lessons:
+        return "lecciones", served, lessons
+    if nodes:
+        return "nodos", served, nodes
+    return "", served, 0
+
+
+async def _employee_rows(
+    db: AsyncSession, *, org_id: uuid.UUID
+) -> list[tuple[uuid.UUID, str, str | None, bool, date | None]]:
+    """Employees of this org, and the single profile column allowed to travel.
+
+    The ``LearnerProfile`` join selects ``role_title`` and nothing else, and the
+    ``org_id`` predicate is repeated on the profile side: a profile row belongs to an
+    organization too, and a join that only constrains the user is one refactor away from
+    not constraining anything.
+    """
+    query = (
+        select(
+            User.id,
+            User.full_name,
+            LearnerProfile.role_title,
+            User.is_active,
+            User.hired_at,
+        )
+        .outerjoin(
+            LearnerProfile,
+            (LearnerProfile.user_id == User.id) & (LearnerProfile.org_id == org_id),
+        )
+        .where(User.org_id == org_id, User.role == UserRole.EMPLOYEE)
+        .order_by(User.full_name)
+    )
+    return [tuple(row) for row in (await db.execute(query)).all()]  # type: ignore[misc]
+
+
+async def _course_rows(db: AsyncSession, *, org_id: uuid.UUID) -> list:
+    query = (
+        select(
+            Course.id,
+            Course.title,
+            Course.status,
+            Course.delivery_mode,
+            Course.schema_status,
+        )
+        .where(Course.org_id == org_id, Course.status != ContentStatus.ARCHIVED)
+        .order_by(Course.title)
+    )
+    return list((await db.execute(query)).all())
+
+
+async def _enrolment_rows(
+    db: AsyncSession, *, org_id: uuid.UUID, course_ids: Sequence[uuid.UUID]
+) -> list:
+    if not course_ids:
+        return []
+    query = (
+        select(
+            Enrollment.user_id,
+            Enrollment.course_id,
+            Enrollment.status,
+            Enrollment.deadline,
+            Enrollment.completed_at,
+        )
+        .join(Course, Course.id == Enrollment.course_id)
+        .where(Course.org_id == org_id, Enrollment.course_id.in_(course_ids))
+    )
+    return list((await db.execute(query)).all())
+
+
+async def _lesson_counts(
+    db: AsyncSession,
+    *,
+    course_ids: Sequence[uuid.UUID],
+    user_ids: Sequence[uuid.UUID],
+) -> tuple[dict[uuid.UUID, int], dict[tuple[uuid.UUID, uuid.UUID], int]]:
+    """``(lessons per course, lessons visited per (user, course))``.
+
+    The v1 completion rule also demands a passing attempt on every exercise of a lesson
+    (``EnrollmentService.compute_progress``). This counts visits only, which can read one
+    or two lessons ahead of the strict rule on a course with exercises. That is a
+    deliberate simplification of a *progress indicator*, and it is why the enrolment
+    ``status`` column — which is written by the strict rule — is what the assistant is
+    told to answer "has X finished?" with.
+    """
+    if not course_ids:
+        return {}, {}
+    totals_query = (
+        select(Module.course_id, func.count(Lesson.id))
+        .join(Lesson, Lesson.module_id == Module.id)
+        .where(Module.course_id.in_(course_ids))
+        .group_by(Module.course_id)
+    )
+    totals = {row[0]: int(row[1]) for row in (await db.execute(totals_query)).all()}
+    if not user_ids:
+        return totals, {}
+    done_query = (
+        select(LessonProgress.user_id, Module.course_id, func.count())
+        .join(Lesson, Lesson.id == LessonProgress.lesson_id)
+        .join(Module, Module.id == Lesson.module_id)
+        .where(
+            Module.course_id.in_(course_ids),
+            LessonProgress.user_id.in_(user_ids),
+        )
+        .group_by(LessonProgress.user_id, Module.course_id)
+    )
+    done = {
+        (row[0], row[1]): int(row[2]) for row in (await db.execute(done_query)).all()
+    }
+    return totals, done
+
+
+async def _node_counts(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    course_ids: Sequence[uuid.UUID],
+    user_ids: Sequence[uuid.UUID],
+) -> tuple[dict[uuid.UUID, int], dict[tuple[uuid.UUID, uuid.UUID], int]]:
+    """``(live nodes per course, nodes mastered per (user, course))``.
+
+    Archived nodes are excluded on both sides, matching ``EnrollmentService.node_progress``:
+    a learner cannot master a node that is no longer served, so counting it would make
+    every course permanently incomplete.
+    """
+    if not course_ids:
+        return {}, {}
+    totals_query = (
+        select(CourseNode.course_id, func.count())
+        .where(
+            CourseNode.org_id == org_id,
+            CourseNode.course_id.in_(course_ids),
+            CourseNode.archived.is_(False),
+        )
+        .group_by(CourseNode.course_id)
+    )
+    totals = {row[0]: int(row[1]) for row in (await db.execute(totals_query)).all()}
+    if not user_ids:
+        return totals, {}
+    done_query = (
+        select(LearnerNodeState.user_id, CourseNode.course_id, func.count())
+        .join(CourseNode, CourseNode.id == LearnerNodeState.node_id)
+        .where(
+            CourseNode.org_id == org_id,
+            CourseNode.course_id.in_(course_ids),
+            CourseNode.archived.is_(False),
+            LearnerNodeState.user_id.in_(user_ids),
+            LearnerNodeState.state == NodeState.MASTERED,
+        )
+        .group_by(LearnerNodeState.user_id, CourseNode.course_id)
+    )
+    done = {
+        (row[0], row[1]): int(row[2]) for row in (await db.execute(done_query)).all()
+    }
+    return totals, done
+
+
+async def _skill_rows(
+    db: AsyncSession, *, org_id: uuid.UUID, user_ids: Sequence[uuid.UUID]
+) -> dict[uuid.UUID, list[tuple[str, str]]]:
+    if not user_ids:
+        return {}
+    query = (
+        select(UserSkill.user_id, Skill.name, UserSkill.level)
+        .join(Skill, Skill.id == UserSkill.skill_id)
+        .where(Skill.org_id == org_id, UserSkill.user_id.in_(user_ids))
+        .order_by(Skill.name)
+    )
+    out: dict[uuid.UUID, list[tuple[str, str]]] = {}
+    for user_id, name, level in (await db.execute(query)).all():
+        out.setdefault(user_id, []).append((name, _enum_value(level)))
+    return out
+
+
+async def _document_titles(
+    db: AsyncSession, *, org_id: uuid.UUID
+) -> tuple[tuple[str, ...], int]:
+    query = (
+        select(Document.title)
+        .where(Document.org_id == org_id)
+        .order_by(Document.created_at.desc())
+    )
+    titles = [row[0] for row in (await db.execute(query)).all()]
+    return tuple(titles[:MAX_DOCUMENTS_LISTED]), len(titles)
+
+
+# --------------------------------------------------------------------------------------
+# Rendering. Pure, so the exact bytes that reach the model are testable without a DB.
+# --------------------------------------------------------------------------------------
+def _level_label(level: str) -> str:
+    return {"low": "bajo", "medium": "medio", "high": "alto"}.get(level, level)
+
+
+def _enrolment_line(fact: EnrolmentFact, today: date) -> str:
+    label = _ENROLMENT_LABELS.get(fact.status, fact.status)
+    bits = [f"{fact.course_title}: {label}"]
+    if fact.total:
+        bits.append(f"{fact.percent}% ({fact.done}/{fact.total} {fact.unit})")
+    if fact.completed_on:
+        bits.append(f"terminado el {fact.completed_on.isoformat()}")
+    if fact.deadline:
+        overdue = " (FUERA DE PLAZO)" if fact.is_overdue(today) else ""
+        bits.append(f"plazo {fact.deadline.isoformat()}{overdue}")
+    return ", ".join(bits)
+
+
+def _employee_block(employee: EmployeeFact, today: date) -> list[str]:
+    head = f"- {employee.full_name}"
+    if employee.role_title:
+        head += f" ({employee.role_title})"
+    if not employee.active:
+        head += " [cuenta desactivada]"
+    if employee.hired_on:
+        head += f", alta {employee.hired_on.isoformat()}"
+    lines = [head]
+    if employee.enrolments:
+        for enrolment in employee.enrolments:
+            lines.append(f"    * {_enrolment_line(enrolment, today)}")
+    else:
+        lines.append("    * sin cursos asignados")
+    if employee.nodes_mastered:
+        lines.append(f"    * nodos dominados: {employee.nodes_mastered}")
+    if employee.skills:
+        rendered = ", ".join(
+            f"{name} ({_level_label(level)})" for name, level in employee.skills
+        )
+        lines.append(f"    * competencias acreditadas: {rendered}")
+    return lines
+
+
+def _course_line(course: CourseFact) -> str:
+    state = course.status
+    if course.delivery == "dinamico":
+        # Only when it is true: "estatico" on every line is noise on a v1 deployment,
+        # where every course is static and the word distinguishes nothing.
+        state += " (dinamico)"
+    bits = [f"- {course.title}: {state}"]
+    if course.units:
+        bits.append(f"{course.units} {course.unit_name}")
+    bits.append(
+        f"{course.enrolled} asignaciones "
+        f"({course.completed} completadas, {course.in_progress} en curso, "
+        f"{course.assigned} sin empezar)"
+    )
+    return ", ".join(bits)
+
+
+def _summary_lines(employees: Sequence[EmployeeFact], today: date) -> list[str]:
+    """The org-level totals, counted here so the model never has to count.
+
+    Measured on the first live run against the demo organization: given only the
+    per-person list, ``groq/llama-3.1-8b-instant`` answered *"como van mis empleados"*
+    with five name-by-name blocks and no headline — correct, and unreadable, and exactly
+    what the rule above ("no sumes, no promedies") obliges it to do when the total it
+    would need is not written down. So the totals are written down. Every figure an admin
+    would open the dashboard for is a literal string in the block, which is what makes
+    "only state what you were given" a usable instruction rather than a gag.
+    """
+    enrolments = [e for person in employees for e in person.enrolments]
+    counted = {
+        "sin empezar": sum(
+            1 for e in enrolments if e.status == EnrollmentStatus.ASSIGNED.value
+        ),
+        "en curso": sum(
+            1 for e in enrolments if e.status == EnrollmentStatus.IN_PROGRESS.value
+        ),
+        "completadas": sum(
+            1 for e in enrolments if e.status == EnrollmentStatus.COMPLETED.value
+        ),
+    }
+    overdue = [
+        person for person in employees if any(e.is_overdue(today) for e in person.enrolments)
+    ]
+    idle = [
+        person
+        for person in employees
+        if person.enrolments
+        and all(e.status == EnrollmentStatus.ASSIGNED.value for e in person.enrolments)
+    ]
+    unassigned = [person for person in employees if not person.enrolments]
+
+    return [
+        "RESUMEN (ya contado, no lo recalcules)",
+        f"- empleados: {len(employees)}",
+        f"- asignaciones de curso: {len(enrolments)} "
+        f"({counted['completadas']} completadas, {counted['en curso']} en curso, "
+        f"{counted['sin empezar']} sin empezar)",
+        f"- empleados que no han empezado NINGUNO de sus cursos: {_named(idle)}",
+        f"- empleados sin ningun curso asignado: {_named(unassigned)}",
+        f"- empleados con algun plazo vencido: {_named(overdue)}",
+    ]
+
+
+def _named(people: Sequence[EmployeeFact], limit: int = 10) -> str:
+    """``"3 (Ana, Berta, Carlos)"``. The count is always exact; the names may be cut.
+
+    An admin asking "quien no ha empezado" wants the names, and on an SME payroll they
+    all fit. Past ``limit`` the line says how many were left out rather than growing
+    without bound, and the count in front of the parenthesis stays the real one — a
+    truncated name list next to a truncated count would be two lies for the price of one.
+    """
+    if not people:
+        return "0"
+    shown = [person.full_name for person in people[:limit]]
+    rest = len(people) - len(shown)
+    tail = f", +{rest} mas" if rest else ""
+    return f"{len(people)} ({', '.join(shown)}{tail})"
+
+
+def render_snapshot(
+    snapshot: OrgSnapshot, *, max_employees: int = MAX_EMPLOYEES_LISTED
+) -> str:
+    """The snapshot as the text the model receives. ``""`` when there is nothing to say.
+
+    Two properties this text has to carry, because the model cannot be trusted to infer
+    either: every number is printed (nothing is left to be computed), and when the
+    employee list is trimmed the trim is stated in the block itself, so "todos mis
+    empleados" cannot be answered from a partial list without the model being told it is
+    partial.
+    """
+    if snapshot.is_empty:
+        return ""
+    today = snapshot.generated_at.date()
+    lines = [
+        f"DATOS DE LA PLATAFORMA - {snapshot.org_name} "
+        f"(al {snapshot.generated_at.date().isoformat()})",
+    ]
+
+    listed = list(snapshot.employees)
+    trimmed = len(listed) > max_employees
+    if trimmed:
+        # Attention first, then whoever fits: a truncated list that drops the overdue
+        # person is worse than no list, because it reads like an all-clear.
+        listed.sort(key=lambda e: (not e.needs_attention(today), e.full_name))
+        listed = listed[:max_employees]
+
+    if snapshot.employees:
+        lines.append("")
+        lines.extend(_summary_lines(snapshot.employees, today))
+
+    header = f"EMPLEADOS ({snapshot.employees_total})"
+    if trimmed:
+        header += (
+            f" - se listan {len(listed)} de {snapshot.employees_total}, "
+            "los que requieren atencion primero. La lista es PARCIAL: dilo si te "
+            "preguntan por el conjunto."
+        )
+    lines.append("")
+    lines.append(header)
+    if listed:
+        for employee in listed:
+            lines.extend(_employee_block(employee, today))
+    else:
+        lines.append("- no hay ningun empleado dado de alta")
+
+    lines.append("")
+    lines.append(f"CURSOS ({len(snapshot.courses)})")
+    if snapshot.courses:
+        lines.extend(_course_line(course) for course in snapshot.courses)
+    else:
+        lines.append("- no hay ningun curso creado")
+
+    lines.append("")
+    lines.append(f"DOCUMENTOS SUBIDOS ({snapshot.documents_total})")
+    if snapshot.documents:
+        lines.extend(f"- {title}" for title in snapshot.documents)
+        if snapshot.documents_total > len(snapshot.documents):
+            lines.append(
+                f"- (+{snapshot.documents_total - len(snapshot.documents)} mas)"
+            )
+    else:
+        lines.append("- no hay ningun documento subido")
+
+    return "\n".join(lines)
+
+
+__all__ = [
+    "FORBIDDEN_PROFILE_FIELDS",
+    "MAX_DOCUMENTS_LISTED",
+    "MAX_EMPLOYEES_LISTED",
+    "MAX_SKILLS_PER_EMPLOYEE",
+    "CourseFact",
+    "EmployeeFact",
+    "EnrolmentFact",
+    "OrgSnapshot",
+    "build_org_snapshot",
+    "render_snapshot",
+]

--- a/apps/skillnet-api/src/services/small_talk.py
+++ b/apps/skillnet-api/src/services/small_talk.py
@@ -1,4 +1,4 @@
-"""Greetings, thanks and goodbyes, answered without a model.
+"""Greetings, thanks, goodbyes and "quien eres", answered without a model.
 
 The reported defect: the owner typed **"que tal"** into the admin assistant and got *"No
 tengo suficiente informacion para responder a tu pregunta."* Nothing was broken in the
@@ -22,6 +22,17 @@ a keyword, not a classifier: "hola, como van mis empleados" is a real question a
 reach the real path. The failure mode of being too narrow is one greeting answered by the
 model, which is survivable; the failure mode of being too wide is a real question answered
 by a canned string, which is not.
+
+**"quien eres" is the same defect as "que tal", and it arrives here for the same reason**
+(reported 2026-07-28). The assistant answered *"No consta la informacion de identidad del
+administrador de la plataforma SkillNet"* — it went looking for the admin's identity in
+the org snapshot, found no such row, and the no-invention rule correctly turned that into
+a non-answer. The mistake was upstream of the model: "who are you" is not a question
+*about the data*, it is a question about the assistant, and the assistant is the one thing
+in the turn that is not in the snapshot. So it never reaches the model either. Unlike a
+greeting this one is not merely cheap-to-can, it is *only* correct canned: the answer is a
+fact about the product, and a model paraphrasing it from a persona string is how a
+capability the assistant does not have ends up promised to an administrator.
 """
 
 from __future__ import annotations
@@ -29,11 +40,13 @@ from __future__ import annotations
 import unicodedata
 from typing import Literal
 
-SmallTalkKind = Literal["greeting", "thanks", "farewell"]
+SmallTalkKind = Literal["greeting", "thanks", "farewell", "identity"]
 
-#: The longest phrase below is four words. Anything longer is a question by construction
-#: and is not even looked up, so a paragraph that happens to start with "hola" is safe.
-MAX_SMALL_TALK_WORDS = 4
+#: The longest phrase below is six words ("en que me puedes ayudar"). Anything longer is a
+#: question by construction and is not even looked up, so a paragraph that happens to
+#: start with "hola" is safe. The cap is only an early-out: what keeps a real question off
+#: this path is the whole-message equality below, not the length.
+MAX_SMALL_TALK_WORDS = 6
 
 _GREETINGS = frozenset(
     {
@@ -90,6 +103,39 @@ _FAREWELLS = frozenset(
     }
 )
 
+#: "Who are you", "what can you do", "help". Every one of these is answered by the same
+#: paragraph, because they are the same question: a person who types any of them wants to
+#: know what this box is for. Deliberately does **not** contain "que puedo hacer" (the
+#: admin asking about their own next action, which is a real question for the data path)
+#: nor anything with a noun of the domain in it.
+_IDENTITY = frozenset(
+    {
+        "quien eres",
+        "quien eres tu",
+        "y tu quien eres",
+        "que eres",
+        "que eres tu",
+        "como te llamas",
+        "que puedes hacer",
+        "que puedes hacer por mi",
+        "que sabes hacer",
+        "que haces",
+        "que haces tu",
+        "para que sirves",
+        "para que vales",
+        "para que sirve esto",
+        "en que me puedes ayudar",
+        "en que puedes ayudarme",
+        "que te puedo preguntar",
+        "que puedo preguntarte",
+        "como funcionas",
+        "ayuda",
+        "help",
+        "who are you",
+        "what can you do",
+    }
+)
+
 #: What the assistant can actually do, in the admin's words. Kept in one place so the
 #: greeting and the goodbye cannot drift into promising different things.
 _CAPABILITIES = (
@@ -105,6 +151,15 @@ _REPLIES: dict[str, str] = {
     "de un plazo— dime y lo miro.",
     "farewell": "Hasta luego. Aqui me tienes cuando quieras revisar el estado de la "
     "formacion.",
+    # Says what it is before it says what it does, and lists only what the data path can
+    # actually deliver today. A capability promised here is a refusal three messages later.
+    "identity": "Soy el asistente de SkillNet, el sitio desde el que gestionas la "
+    f"formacion de tu equipo. {_CAPABILITIES}\n\n"
+    "Lo que no puedo: no veo como aprende cada persona (sus preferencias ni sus "
+    "necesidades de accesibilidad son privadas), y no me invento ninguna cifra ni "
+    "ningun plazo que no este en la plataforma.\n\n"
+    'Prueba con "¿quien no ha empezado sus cursos?", "¿que plazos se estan pasando?" '
+    'o "¿que dice el manual de alergenos sobre las trazas?".',
 }
 
 
@@ -123,7 +178,7 @@ def _fold(text: str) -> str:
 
 
 def classify_small_talk(message: str) -> SmallTalkKind | None:
-    """``greeting`` / ``thanks`` / ``farewell``, or ``None`` for anything with a question in it."""
+    """One of the four kinds, or ``None`` for anything that is a real question."""
     folded = _fold(message)
     if not folded or len(folded.split()) > MAX_SMALL_TALK_WORDS:
         return None
@@ -131,6 +186,7 @@ def classify_small_talk(message: str) -> SmallTalkKind | None:
         ("greeting", _GREETINGS),
         ("thanks", _THANKS),
         ("farewell", _FAREWELLS),
+        ("identity", _IDENTITY),
     ):
         if folded in {_fold(phrase) for phrase in phrases}:
             return kind  # type: ignore[return-value]

--- a/apps/skillnet-api/src/services/small_talk.py
+++ b/apps/skillnet-api/src/services/small_talk.py
@@ -1,0 +1,151 @@
+"""Greetings, thanks and goodbyes, answered without a model.
+
+The reported defect: the owner typed **"que tal"** into the admin assistant and got *"No
+tengo suficiente informacion para responder a tu pregunta."* Nothing was broken in the
+retrieval layer — that is the point. The organization has documents, so the turn grounded
+on rung 2, the model was handed four kilobytes of an allergen manual and the question
+"que tal", and it correctly concluded that the manual does not answer it. A refusal to a
+greeting is the single cheapest way to make a product feel dead, and no amount of persona
+text fixes it, because the model is not wrong: it *was* asked to answer from a document.
+
+So a greeting never reaches the model at all. The reply is written here, streamed as if it
+had been generated, and costs zero tokens, zero latency and zero chance of hallucinating a
+figure about somebody's training record. It is also the only place in the assistant where
+a canned string is the *better* answer: "hola" has one correct response and it is the same
+every time, and this one doubles as the discoverability the surface otherwise lacks — the
+admin is told what they can ask for, which is exactly what a person typing "que tal" at a
+new tool is trying to find out.
+
+**The matcher is deliberately unable to grow.** It matches the *whole* message against a
+closed set of phrases, after folding accents and stripping punctuation. Not a prefix, not
+a keyword, not a classifier: "hola, como van mis empleados" is a real question and must
+reach the real path. The failure mode of being too narrow is one greeting answered by the
+model, which is survivable; the failure mode of being too wide is a real question answered
+by a canned string, which is not.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from typing import Literal
+
+SmallTalkKind = Literal["greeting", "thanks", "farewell"]
+
+#: The longest phrase below is four words. Anything longer is a question by construction
+#: and is not even looked up, so a paragraph that happens to start with "hola" is safe.
+MAX_SMALL_TALK_WORDS = 4
+
+_GREETINGS = frozenset(
+    {
+        "hola",
+        "holaa",
+        "buenas",
+        "hey",
+        "ey",
+        "que tal",
+        "que tal todo",
+        "que hay",
+        "como estas",
+        "como va",
+        "como va todo",
+        "como te va",
+        "buenos dias",
+        "buen dia",
+        "buenas tardes",
+        "buenas noches",
+        "hola que tal",
+        "hola buenas",
+        "buenas hola",
+        "hi",
+        "hello",
+    }
+)
+
+_THANKS = frozenset(
+    {
+        "gracias",
+        "muchas gracias",
+        "mil gracias",
+        "muchisimas gracias",
+        "gracias!",
+        "genial gracias",
+        "perfecto gracias",
+        "vale gracias",
+        "ok gracias",
+        "thanks",
+        "thank you",
+    }
+)
+
+_FAREWELLS = frozenset(
+    {
+        "adios",
+        "hasta luego",
+        "hasta manana",
+        "nos vemos",
+        "chao",
+        "chau",
+        "buenas noches me voy",
+        "bye",
+    }
+)
+
+#: What the assistant can actually do, in the admin's words. Kept in one place so the
+#: greeting and the goodbye cannot drift into promising different things.
+_CAPABILITIES = (
+    "Puedo contarte como van tus empleados (quien ha terminado, quien no ha empezado y "
+    "que plazos se estan pasando), que cursos y documentos tienes, y responderte sobre "
+    "el contenido de la documentacion que has subido."
+)
+
+_REPLIES: dict[str, str] = {
+    "greeting": f"Hola. Todo en orden por aqui. {_CAPABILITIES}\n\n"
+    "Prueba con \"¿como van mis empleados?\" o \"¿que cursos tengo publicados?\".",
+    "thanks": "A mandar. Si necesitas otra cosa —estado de un empleado, de un curso o "
+    "de un plazo— dime y lo miro.",
+    "farewell": "Hasta luego. Aqui me tienes cuando quieras revisar el estado de la "
+    "formacion.",
+}
+
+
+def _fold(text: str) -> str:
+    """Lower-case, strip accents and drop everything that is not a letter or a space.
+
+    Same folding idea as ``src/services/retrieval.py``: an admin writes "¿Qué tal?" and
+    the table is written without accents, because this whole repository is.
+    """
+    decomposed = unicodedata.normalize("NFKD", text.strip().lower())
+    stripped = "".join(char for char in decomposed if not unicodedata.combining(char))
+    cleaned = "".join(
+        char if (char.isalnum() or char.isspace()) else " " for char in stripped
+    )
+    return " ".join(cleaned.split())
+
+
+def classify_small_talk(message: str) -> SmallTalkKind | None:
+    """``greeting`` / ``thanks`` / ``farewell``, or ``None`` for anything with a question in it."""
+    folded = _fold(message)
+    if not folded or len(folded.split()) > MAX_SMALL_TALK_WORDS:
+        return None
+    for kind, phrases in (
+        ("greeting", _GREETINGS),
+        ("thanks", _THANKS),
+        ("farewell", _FAREWELLS),
+    ):
+        if folded in {_fold(phrase) for phrase in phrases}:
+            return kind  # type: ignore[return-value]
+    return None
+
+
+def small_talk_reply(message: str) -> str | None:
+    """The canned answer for ``message``, or ``None`` when it is a real question."""
+    kind = classify_small_talk(message)
+    return _REPLIES[kind] if kind else None
+
+
+__all__ = [
+    "MAX_SMALL_TALK_WORDS",
+    "SmallTalkKind",
+    "classify_small_talk",
+    "small_talk_reply",
+]

--- a/apps/skillnet-api/tests/test_admin_assistant.py
+++ b/apps/skillnet-api/tests/test_admin_assistant.py
@@ -89,6 +89,66 @@ def test_the_prompt_points_at_the_precounted_totals_instead_of_a_headcount() -> 
     assert "no es una accion, es relleno" in prompt
 
 
+def test_the_closing_action_is_scoped_to_questions_about_people_and_courses() -> None:
+    """Reported 2026-07-28: "explicame paso a paso como atender una consulta de alergenos"
+    got five correct steps and then "Escribe a Aitana, que no ha abierto sus tres cursos".
+
+    Aitana has nothing to do with the question. The rule that makes a *management* answer
+    end in something actionable was firing on a *content* answer, and an answer that ends
+    by nagging about an unrelated person reads as broken. So the block now sorts the
+    question first and says, in imperative, that the close is forbidden outside case (A).
+    """
+    prompt = admin_system_prompt("document", org_data=True)
+
+    assert "Pregunta DE GESTION" in prompt
+    assert "Pregunta DE CONTENIDO" in prompt
+    assert "NO se aplica y esta PROHIBIDA" in prompt
+    # The failing turn is quoted verbatim, the way "habla con el encargado" already is.
+    assert "escribe a Aitana" in prompt
+    assert "La respuesta termina cuando termina el contenido" in prompt
+
+
+def test_a_question_about_the_assistant_is_not_looked_up_in_the_data() -> None:
+    """"quien eres" -> "No consta la informacion de identidad del administrador"."""
+    prompt = admin_system_prompt("document", org_data=True)
+    assert "la respuesta eres TU" in prompt
+    assert "busques en los datos de la organizacion" in prompt
+    assert "ahi estan sus empleados y sus cursos" in prompt
+
+
+def test_no_question_is_allowed_to_be_a_dead_end() -> None:
+    """"usa openui para esta respuesta" -> "no puedo comprender la pregunta"."""
+    for grounding in ("chunks", "document", "general"):
+        for prompt in (
+            admin_system_prompt(grounding),
+            admin_system_prompt(grounding, org_data=True),
+        ):
+            assert "no puedo comprender la pregunta" in prompt
+            assert "Nunca escribas" in prompt
+    # An instruction about the shape of the answer is answered, not refused.
+    persona = admin_system_prompt("general")
+    assert "instruccion sobre el FORMATO" in persona
+
+
+def test_the_context_is_never_the_answer() -> None:
+    """Measured live on the first fix of the dead-end: telling the model not to refuse
+    *"usa openui para esta respuesta"* got it to paste the entire platform data block and
+    both documents into the bubble instead.
+
+    Trading a refusal for a context dump is not a fix — it is the same non-answer, at
+    four kilobytes, with five employees' records in it. So "do not stall" and "do not
+    empty the context onto the screen" have to be stated together, and a format
+    instruction with no subject is a question to ask back, not an order to fill.
+    """
+    for prompt in (
+        admin_system_prompt("document"),
+        admin_system_prompt("document", org_data=True),
+    ):
+        assert "No copias NUNCA, tal cual, el bloque de datos" in prompt
+        assert "no es responder, es vaciarlo en la pantalla" in prompt
+        assert "no te dicen SOBRE QUE" in prompt
+
+
 def test_the_prompt_tells_the_model_the_private_half_is_not_missing_but_withheld() -> None:
     """So "no lo tengo" is answered as policy, not as a gap to be filled by guessing."""
     prompt = admin_system_prompt("document", org_data=True)
@@ -136,6 +196,42 @@ def test_a_farewell_is_its_own_reply(message: str) -> None:
 @pytest.mark.parametrize(
     "message",
     [
+        "quien eres",
+        "¿Quién eres?",
+        "  QUE ERES  ",
+        "que puedes hacer",
+        "para que sirves",
+        "ayuda",
+        "en que me puedes ayudar",
+        "como funcionas",
+        "who are you",
+    ],
+)
+def test_asking_the_assistant_about_itself_is_answered_here(message: str) -> None:
+    """Reported: *"quien eres"* -> *"No consta la informacion de identidad del
+    administrador de la plataforma SkillNet."*
+
+    It searched the org snapshot for the admin's identity. The assistant is the one thing
+    in the turn that is not in the snapshot, so the question never gets there.
+    """
+    assert classify_small_talk(message) == "identity"
+
+
+def test_the_identity_reply_says_what_it_is_what_it_does_and_what_it_will_not_do() -> None:
+    reply = small_talk_reply("quien eres") or ""
+
+    assert "asistente de SkillNet" in reply
+    assert "empleados" in reply
+    # The two honest limits, said before anyone has to discover them.
+    assert "privadas" in reply
+    assert "no me invento" in reply
+    # Not the greeting: "hola" and "quien eres" are different questions.
+    assert reply != small_talk_reply("hola")
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
         "hola, como van mis empleados",
         "que tal va el curso de alergenos",
         "gracias, y quien no ha empezado?",
@@ -143,12 +239,35 @@ def test_a_farewell_is_its_own_reply(message: str) -> None:
         "buenas, necesito el listado de plazos",
         "",
         "   ",
+        # Near misses of the identity table that are real questions about the data.
+        "quien eres tu para Lucia",
+        "que puedo hacer con Aitana",
+        "que puedes hacer con los cursos sin publicar",
+        "ayuda a Lucia",
+        "para que sirve el curso de alergenos",
     ],
 )
 def test_a_real_question_is_never_answered_from_the_can(message: str) -> None:
     """Too narrow costs one greeting to the model. Too wide costs a real answer."""
     assert classify_small_talk(message) is None
     assert small_talk_reply(message) is None
+
+
+async def test_asking_who_it_is_costs_nothing_and_never_reaches_the_data(
+    monkeypatch,
+) -> None:
+    """Zero tokens, zero snapshot queries, and it cannot say "no consta"."""
+    llm = _RecordingLLM()
+    events, repo, seen = await _run_admin(monkeypatch, llm, message="quien eres")
+    answer = "".join(data["content"] for name, data in events if name == "token")
+
+    assert llm.calls == []
+    assert llm.completions == 0
+    assert seen == {}  # the snapshot was never assembled
+    assert "No consta" not in answer
+    assert "asistente de SkillNet" in answer
+    assert repo.messages[-1].content == answer
+    assert repo.messages[-1].message_metadata["small_talk"] is True
 
 
 def test_the_greeting_reply_says_what_the_assistant_can_do() -> None:
@@ -351,6 +470,29 @@ async def test_a_greeting_never_reaches_the_provider(monkeypatch) -> None:
 async def test_a_greeting_does_not_pay_for_a_snapshot_either(monkeypatch) -> None:
     _, _, seen = await _run_admin(monkeypatch, _RecordingLLM(), message="hola")
     assert "org_id" not in seen
+
+
+@pytest.mark.parametrize("message", ["hola", "quien eres", "gracias"])
+async def test_a_canned_answer_does_not_pay_for_a_layout_call_either(
+    monkeypatch, message: str
+) -> None:
+    """Zero tokens means zero, on both calls.
+
+    Caught live: the identity reply is comfortably longer than ``MIN_LAYOUT_CHARS``, so
+    the moment the admin path started laying out, the one question guaranteed never to
+    reach a provider began emitting ``layout_start`` and paying for a second call to
+    reformat a string this repository wrote itself.
+    """
+    llm = _RecordingLLM()
+    service, user, _ = _service(monkeypatch, llm)
+    service.generative_ui = True
+    events = _events(
+        [event async for event in service.stream_admin(user, message, None, None)]
+    )
+
+    assert llm.completions == 0
+    assert "layout_start" not in [name for name, _ in events]
+    assert [name for name, _ in events][-1] == "done"
 
 
 async def test_a_greeting_still_closes_the_stream_the_way_every_turn_does(

--- a/apps/skillnet-api/tests/test_admin_assistant.py
+++ b/apps/skillnet-api/tests/test_admin_assistant.py
@@ -1,0 +1,380 @@
+"""The admin assistant answers about the organization, and says hello back.
+
+Both defects were reported from a live session at ``/admin/chat`` on 2026-07-27, and they
+are the same defect twice: the assistant was the employee tutor with a different persona,
+so it could read training *documents* and nothing else.
+
+* *"como van mis empleados"* -> four bullets of generic management advice ("revisa el
+  parte de incidencias", "habla con el encargado"), while five employees and their
+  progress sat in the database it administers.
+* *"que tal"* -> *"No tengo suficiente informacion para responder a tu pregunta."*
+
+The tests below assert the mechanism, never the model's prose: that the facts are in the
+turn, that the private ones are not, that the greeting never reaches a provider, and that
+the employee tutor is untouched by all of it.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import date, datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from src.llm.prompts.admin import (
+    ADMIN_DATA_BLOCK,
+    ADMIN_PROMPT_VERSION,
+    admin_system_prompt,
+    build_admin_turn,
+)
+from src.services import chat_service as chat_module
+from src.services.chat_service import ChatService, _canned_chunks
+from src.services.org_snapshot import EmployeeFact, EnrolmentFact, OrgSnapshot
+from src.services.retrieval import GroundedContext
+from src.services.small_talk import classify_small_talk, small_talk_reply
+
+NOW = datetime(2026, 7, 28, 9, 0, tzinfo=timezone.utc)
+
+SNAPSHOT = OrgSnapshot(
+    org_name="Panaderia y Cafeteria La Espiga S.L.",
+    generated_at=NOW,
+    employees=(
+        EmployeeFact(
+            full_name="Lucia Fernandez Vila",
+            role_title="Dependiente",
+            enrolments=(
+                EnrolmentFact(
+                    "Alergenos", "in_progress", 2, 5, "nodos", deadline=date(2026, 8, 15)
+                ),
+            ),
+        ),
+    ),
+    employees_total=1,
+    documents=("Manual de alergenos",),
+    documents_total=1,
+)
+
+
+# -- the prompt ---------------------------------------------------------------------
+def test_the_data_block_only_appears_when_there_is_data() -> None:
+    assert ADMIN_DATA_BLOCK not in admin_system_prompt("document")
+    assert ADMIN_DATA_BLOCK in admin_system_prompt("document", org_data=True)
+
+
+def test_the_data_prompt_forbids_the_number_the_model_did_not_get() -> None:
+    """The one rule worth more than the feature: a wrong training figure about a named
+    person is worse than "no lo se"."""
+    prompt = admin_system_prompt("general", org_data=True)
+    assert "tiene que estar literalmente en el bloque" in prompt
+    assert "No sumes" in prompt
+    assert "no consta" in prompt
+
+
+def test_the_data_prompt_names_the_failure_it_replaces() -> None:
+    """Told only "answer from the data", a small model still writes the advice bullets."""
+    prompt = admin_system_prompt("document", org_data=True)
+    assert "habla con el encargado" in prompt
+    assert "nombres propios y numeros concretos" in prompt
+
+
+def test_the_prompt_points_at_the_precounted_totals_instead_of_a_headcount() -> None:
+    """The first live run answered with five name-by-name blocks and no headline."""
+    prompt = admin_system_prompt("document", org_data=True)
+    assert "RESUMEN" in prompt
+    assert "Empieza SIEMPRE por el titular" in prompt
+    # ...and it closed with "revisa el estado de cada empleado", which is the advice bullet
+    # wearing a hat.
+    assert "no es una accion, es relleno" in prompt
+
+
+def test_the_prompt_tells_the_model_the_private_half_is_not_missing_but_withheld() -> None:
+    """So "no lo tengo" is answered as policy, not as a gap to be filled by guessing."""
+    prompt = admin_system_prompt("document", org_data=True)
+    assert "privado de cada empleado" in prompt
+    assert "accesibilidad" in prompt
+
+
+def test_the_question_is_the_last_thing_in_the_turn() -> None:
+    turn = build_admin_turn("document", "[Fuente 1: Manual]\ntexto", "DATOS...", "¿como van?")
+    assert turn.rstrip().endswith("Pregunta: ¿como van?")
+    assert turn.startswith("DATOS...")
+
+
+def test_a_turn_with_data_and_no_documents_still_carries_the_data() -> None:
+    turn = build_admin_turn("general", "", "DATOS DE LA PLATAFORMA — X", "¿cuantos hay?")
+    assert "DATOS DE LA PLATAFORMA" in turn
+    assert "criterio general" not in turn
+
+
+def test_a_turn_with_neither_falls_back_to_the_general_instruction() -> None:
+    turn = build_admin_turn("general", "", "", "¿que es un alergeno?")
+    assert "criterio general" in turn
+    assert "¿que es un alergeno?" in turn
+
+
+# -- small talk ---------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "message",
+    ["hola", "Hola", "  hola  ", "¿Qué tal?", "que tal", "buenas", "Buenos dias"],
+)
+def test_a_greeting_is_recognised_however_it_is_typed(message: str) -> None:
+    assert classify_small_talk(message) == "greeting"
+
+
+@pytest.mark.parametrize("message", ["gracias", "Muchas gracias!", "ok gracias"])
+def test_thanks_is_its_own_reply(message: str) -> None:
+    assert classify_small_talk(message) == "thanks"
+
+
+@pytest.mark.parametrize("message", ["adios", "Hasta luego", "nos vemos"])
+def test_a_farewell_is_its_own_reply(message: str) -> None:
+    assert classify_small_talk(message) == "farewell"
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "hola, como van mis empleados",
+        "que tal va el curso de alergenos",
+        "gracias, y quien no ha empezado?",
+        "como van mis empleados",
+        "buenas, necesito el listado de plazos",
+        "",
+        "   ",
+    ],
+)
+def test_a_real_question_is_never_answered_from_the_can(message: str) -> None:
+    """Too narrow costs one greeting to the model. Too wide costs a real answer."""
+    assert classify_small_talk(message) is None
+    assert small_talk_reply(message) is None
+
+
+def test_the_greeting_reply_says_what_the_assistant_can_do() -> None:
+    reply = small_talk_reply("hola") or ""
+    assert "empleados" in reply
+    assert "cursos" in reply
+    # A greeting that answers "hola" and stops is the refusal with better manners.
+    assert len(reply) > 120
+
+
+def test_canned_chunks_reassemble_to_exactly_the_reply() -> None:
+    for text in ("hola", "una frase algo mas larga que la anterior, con coma", ""):
+        assert "".join(_canned_chunks(text)) == text
+
+
+# -- the stream ---------------------------------------------------------------------
+class _FakeDB:
+    async def commit(self) -> None: ...
+    async def rollback(self) -> None: ...
+
+
+class _FakeRepo:
+    def __init__(self) -> None:
+        self.messages: list[SimpleNamespace] = []
+
+    async def create_session(self, **_kwargs):
+        return SimpleNamespace(id=uuid.uuid4())
+
+    async def get_owned_session(self, session_id, _user_id):
+        return SimpleNamespace(id=session_id)
+
+    async def recent_messages(self, _session_id, _limit):
+        return []
+
+    async def add_message(self, *, session_id, role, content, metadata=None):
+        message = SimpleNamespace(
+            id=uuid.uuid4(),
+            session_id=session_id,
+            role=role,
+            content=content,
+            message_metadata=metadata or {},
+        )
+        self.messages.append(message)
+        return message
+
+
+class _RecordingLLM:
+    """Records the messages it was asked to stream, then streams a fixed answer."""
+
+    def __init__(self, answer: str = "Lucia va por el 40%.") -> None:
+        self.answer = answer
+        self.calls: list[list[dict]] = []
+        self.completions = 0
+
+    async def stream(self, messages, **_kwargs):
+        self.calls.append(list(messages))
+        yield self.answer
+
+    async def complete(self, _system, _user, **_kwargs):
+        self.completions += 1
+        return "NO_UI"
+
+    @property
+    def system(self) -> str:
+        return self.calls[-1][0]["content"]
+
+    @property
+    def turn(self) -> str:
+        return self.calls[-1][-1]["content"]
+
+
+def _events(chunks: list[str]) -> list[tuple[str, dict]]:
+    out: list[tuple[str, dict]] = []
+    for chunk in chunks:
+        head, _, tail = chunk.partition("\n")
+        out.append((head.removeprefix("event: "), json.loads(tail.removeprefix("data: "))))
+    return out
+
+
+def _service(monkeypatch, llm, *, snapshot=SNAPSHOT, grounding="document", org_id=None):
+    async def fake_ground(*_args, **_kwargs):
+        if grounding == "general":
+            return GroundedContext("general")
+        return GroundedContext(
+            grounding,
+            "[Fuente 1: Manual (documento completo)]\ntexto",
+            [{"document": "Manual", "section": "documento completo", "page": None}],
+        )
+
+    seen: dict[str, object] = {}
+
+    async def fake_build(_db, *, org_id, now=None):
+        seen["org_id"] = org_id
+        if isinstance(snapshot, Exception):
+            raise snapshot
+        return snapshot
+
+    monkeypatch.setattr(chat_module, "ground_question", fake_ground)
+    monkeypatch.setattr(chat_module, "build_org_snapshot", fake_build)
+    service = ChatService(_FakeDB(), llm, object())  # type: ignore[arg-type]
+    service.repo = _FakeRepo()  # type: ignore[assignment]
+    user = SimpleNamespace(id=uuid.uuid4(), org_id=org_id or uuid.uuid4())
+    return service, user, seen
+
+
+async def _run_admin(monkeypatch, llm, message="como van mis empleados", **kwargs):
+    service, user, seen = _service(monkeypatch, llm, **kwargs)
+    chunks = [event async for event in service.stream_admin(user, message, None, None)]
+    return _events(chunks), service.repo, seen  # type: ignore[return-value]
+
+
+async def test_the_reported_question_reaches_the_model_with_the_answer_in_it(
+    monkeypatch,
+) -> None:
+    """The whole fix in one assertion: the names and the numbers are in the turn."""
+    llm = _RecordingLLM()
+    await _run_admin(monkeypatch, llm)
+
+    assert "DATOS DE LA PLATAFORMA" in llm.turn
+    assert "Lucia Fernandez Vila (Dependiente)" in llm.turn
+    assert "40% (2/5 nodos)" in llm.turn
+    assert ADMIN_DATA_BLOCK in llm.system
+
+
+async def test_the_snapshot_is_announced_as_its_own_event(monkeypatch) -> None:
+    events, _, _ = await _run_admin(monkeypatch, _RecordingLLM())
+    names = [name for name, _ in events]
+    org_data = next(data for name, data in events if name == "org_data")
+
+    # ``grounding`` is about documents; the platform data is a separate axis.
+    assert names.index("grounding") < names.index("org_data") < names.index("token")
+    assert org_data["employees"] == 1
+    assert org_data["generated_at"] == NOW.isoformat()
+
+
+async def test_the_snapshot_is_scoped_to_the_callers_organization(monkeypatch) -> None:
+    """One org today. A query that assumes so is the query that leaks when there are two."""
+    org_id = uuid.uuid4()
+    _, _, seen = await _run_admin(monkeypatch, _RecordingLLM(), org_id=org_id)
+    assert seen["org_id"] == org_id
+
+
+async def test_the_snapshot_is_persisted_alongside_the_answer(monkeypatch) -> None:
+    _, repo, _ = await _run_admin(monkeypatch, _RecordingLLM())
+    metadata = repo.messages[-1].message_metadata
+
+    assert metadata["prompt_version"] == ADMIN_PROMPT_VERSION
+    assert metadata["org_data"]["employees"] == 1
+
+
+async def test_a_broken_snapshot_costs_the_data_and_never_the_answer(monkeypatch) -> None:
+    """Eight aggregate queries is eight chances to fail; none of them may eat the turn."""
+    llm = _RecordingLLM()
+    events, _, _ = await _run_admin(
+        monkeypatch, llm, snapshot=RuntimeError("relation does not exist")
+    )
+    names = [name for name, _ in events]
+
+    assert "error" not in names
+    assert "org_data" not in names
+    assert "done" in names
+    assert "DATOS DE LA PLATAFORMA" not in llm.turn
+    # ...and the assistant it degrades to is exactly yesterday's document assistant.
+    assert ADMIN_DATA_BLOCK not in llm.system
+    assert "documentos de la organizacion" in llm.system
+
+
+async def test_an_organization_with_nothing_in_it_adds_no_empty_block(monkeypatch) -> None:
+    llm = _RecordingLLM()
+    empty = OrgSnapshot(org_name="Nueva S.L.", generated_at=NOW)
+    events, _, _ = await _run_admin(monkeypatch, llm, snapshot=empty)
+
+    assert "org_data" not in [name for name, _ in events]
+    assert "DATOS DE LA PLATAFORMA" not in llm.turn
+
+
+async def test_the_snapshot_travels_even_when_no_document_matched(monkeypatch) -> None:
+    """Rung 3 is about documents. "Cuantos empleados tengo" needs none of them."""
+    llm = _RecordingLLM()
+    await _run_admin(monkeypatch, llm, grounding="general")
+
+    assert "DATOS DE LA PLATAFORMA" in llm.turn
+    assert "Lucia Fernandez Vila" in llm.turn
+
+
+async def test_a_greeting_never_reaches_the_provider(monkeypatch) -> None:
+    """"que tal" used to be answered "No tengo suficiente informacion"."""
+    llm = _RecordingLLM()
+    events, repo, _ = await _run_admin(monkeypatch, llm, message="que tal")
+    answer = "".join(data["content"] for name, data in events if name == "token")
+
+    assert llm.calls == []
+    assert llm.completions == 0
+    assert "No tengo" not in answer
+    assert "empleados" in answer
+    assert repo.messages[-1].content == answer
+    assert repo.messages[-1].message_metadata["small_talk"] is True
+
+
+async def test_a_greeting_does_not_pay_for_a_snapshot_either(monkeypatch) -> None:
+    _, _, seen = await _run_admin(monkeypatch, _RecordingLLM(), message="hola")
+    assert "org_id" not in seen
+
+
+async def test_a_greeting_still_closes_the_stream_the_way_every_turn_does(
+    monkeypatch,
+) -> None:
+    """The frontend re-enables the composer on ``done``; a canned turn must send one."""
+    events, _, _ = await _run_admin(monkeypatch, _RecordingLLM(), message="gracias")
+    names = [name for name, _ in events]
+
+    assert names[0] == "grounding"
+    assert "token" in names
+    assert names[-1] == "done"
+    assert next(d for n, d in events if n == "citations")["citations"] == []
+
+
+# -- the employee tutor is untouched --------------------------------------------------
+async def test_the_tutor_gets_no_snapshot_and_no_canned_greeting(monkeypatch) -> None:
+    """Everything above is on the ``admin`` path. The tutor's ladder landed yesterday."""
+    llm = _RecordingLLM()
+    service, user, seen = _service(monkeypatch, llm)
+    events = [event async for event in service.stream_tutor(user, "hola", None, None)]
+
+    assert seen == {}
+    assert llm.calls, "the tutor still calls the model for a greeting"
+    assert "DATOS DE LA PLATAFORMA" not in llm.turn
+    assert "tutor de SkillNet" in llm.system
+    assert "org_data" not in [name for name, _ in _events(events)]

--- a/apps/skillnet-api/tests/test_chat_gen_ui.py
+++ b/apps/skillnet-api/tests/test_chat_gen_ui.py
@@ -1,6 +1,6 @@
 """Generative UI in the chat: the gate on the layout call, and the stream around it.
 
-Two properties are worth more than the rest and each has its own block below:
+Three properties are worth more than the rest and each has its own block below:
 
 1. **The browser never receives the model's bytes.** Everything served is the
    re-serialization of a validated ``UISpec`` — the same rule as a node render, applied to
@@ -8,22 +8,37 @@ Two properties are worth more than the rest and each has its own block below:
    it.
 2. **A failed layout costs nothing.** Every rejection path ends with the prose the learner
    has already read, never with a blank bubble and never with a slower chat.
+3. **The model classifies and populates; the server writes the program** (2026-07-28).
+   The assertions in "classify + populate" below are about what the model can no longer
+   do: it cannot pass a named argument, cannot put an accent in an identifier and cannot
+   blow the line cap, because it does not type the program. Every one of those was a real
+   rejection in ``bench_out/failures/``.
 """
 
 from __future__ import annotations
 
+import inspect
 import json
 import uuid
 from types import SimpleNamespace
 
 import pytest
 
-from src.llm.prompts.tutor import NO_UI_SENTINEL, chat_ui_system
+from src.llm.prompts.tutor import (
+    CHAT_LAYOUT_SYSTEM,
+    CHAT_SHAPES,
+    MAX_STEPS,
+    NO_UI_SENTINEL,
+    chat_ui_system,
+)
 from src.routes import chat as chat_route
 from src.services import chat_service as chat_module
 from src.services.chat_service import (
     MIN_LAYOUT_CHARS,
     ChatService,
+    emit_chat_program,
+    invented_figures,
+    parse_layout_json,
     strip_no_ui,
     validate_chat_program,
 )
@@ -46,6 +61,39 @@ REACTIVE_PROGRAM = (
     'root = Stack([intro], "md")\n'
     'intro = TextContent($nombre, "lead")\n'
 )
+
+#: What the layout model returns now: a shape and its fields, never markup.
+STEPS_PAYLOAD = json.dumps(
+    {
+        "shape": "steps",
+        # No digit anywhere: ``LONG_ANSWER`` writes "catorce" in words, and the
+        # invented-figure guard is right to refuse a "14" the prose never showed.
+        "lead": "Los alergenos son las sustancias de declaracion obligatoria.",
+        "title": "Como se informa",
+        "steps": ["Consulta la ficha del producto", "Lee lo que pone en voz alta"],
+    }
+)
+
+TABLE_PAYLOAD = json.dumps(
+    {
+        "shape": "table",
+        "lead": "Asi va cada persona.",
+        "headers": ["Empleado", "Curso", "Estado"],
+        "rows": [
+            ["Lucia Fernandez Vila", "Alergenos", "40%"],
+            ["Aitana Ruiz", "Higiene", "sin empezar"],
+        ],
+    }
+)
+
+PROSE_PAYLOAD = json.dumps({"shape": "prose"})
+
+#: The admin answer the table above re-lays. Every figure in ``TABLE_PAYLOAD`` is in here,
+#: which is the only way a table about people's training records is allowed to exist.
+ADMIN_ANSWER = (
+    "Tienes dos personas con formacion abierta. Lucia Fernandez Vila va por el 40% del "
+    "curso de Alergenos y Aitana Ruiz no ha empezado el de Higiene. "
+) * 2
 
 
 # -- the verdict token --------------------------------------------------------------
@@ -110,11 +158,236 @@ def test_no_ui_is_refused_quietly() -> None:
     assert validate_chat_program(NO_UI_SENTINEL) is None
 
 
-def test_the_layout_prompt_forbids_quiz_and_teaches_the_same_catalogue() -> None:
+def test_the_node_layout_prompt_still_teaches_the_shared_catalogue() -> None:
+    """``chat_ui_system`` is no longer on the chat's path; the node runtime's rules are.
+
+    Kept as a test so the artefact those rules are generated from cannot drift unnoticed
+    while nothing in the chat reads it any more.
+    """
     system = chat_ui_system()
     assert "Prohibido QuizItem" in system
     assert "StepSequence(title: string, steps: string[])" in system  # the shared artefact
     assert NO_UI_SENTINEL in system
+
+
+# -- classify + populate ---------------------------------------------------------------
+def test_the_layout_prompt_asks_for_json_and_forbids_markup() -> None:
+    """The whole point: the model is told it is not writing a program."""
+    assert "NO escribes codigo" in CHAT_LAYOUT_SYSTEM
+    assert "UN objeto JSON" in CHAT_LAYOUT_SYSTEM
+    # ...and the five shapes are all offered, "prose" included, or the model has to
+    # squeeze a paragraph into a table.
+    for shape in CHAT_SHAPES:
+        assert f'"{shape}"' in CHAT_LAYOUT_SYSTEM
+    # The rule that outranks the layout: this call may not touch a number.
+    assert "No cambias ninguna cifra" in CHAT_LAYOUT_SYSTEM
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"shape": "steps", "lead": "L", "title": "T", "steps": ["a", "b"]}, "StepSequence"),
+        (
+            {"shape": "table", "lead": "L", "headers": ["a", "b"], "rows": [["1", "2"], ["3", "4"]]},
+            "Table",
+        ),
+        ({"shape": "callout", "lead": "L", "tone": "warn", "text": "x"}, "Callout"),
+        (
+            {
+                "shape": "definition",
+                "lead": "L",
+                "title": "T",
+                "points": [{"term": "a", "detail": "b"}, {"term": "c", "detail": "d"}],
+            },
+            "Card",
+        ),
+    ],
+)
+def test_each_shape_emits_a_program_the_gate_accepts(payload, expected) -> None:
+    program = emit_chat_program(payload)
+    assert program is not None and expected in program
+    # And the gate — the same one a node render goes through — takes it unchanged.
+    assert validate_chat_program(program) == program
+
+
+def test_the_emitted_program_is_already_canonical() -> None:
+    """``serialize(parse(emitted)) == emitted``, so the gate is a check, not a rewrite.
+
+    Worth its own assertion: it is the evidence that the server writes the *canonical*
+    form rather than something the backend has to tidy up, which is what makes the round
+    trip through ``canonicalize`` free of surprises.
+    """
+    program = emit_chat_program(json.loads(TABLE_PAYLOAD))
+    assert program is not None
+    assert validate_chat_program(program) == program
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"shape": "prose"},
+        {"shape": "prose", "lead": "sobra"},
+        {"shape": "diagram", "lead": "L"},  # not in the enum
+        {"shape": "steps", "lead": "L", "title": "T", "steps": ["solo uno"]},
+        {"shape": "steps", "lead": "L", "title": "T", "steps": ["x"] * (MAX_STEPS + 1)},
+        {"shape": "steps", "lead": "L", "steps": ["a", "b"]},  # no title
+        {"shape": "table", "lead": "L", "headers": ["a", "b"], "rows": [["1"], ["2", "3"]]},
+        {"shape": "table", "lead": "L", "headers": ["a"], "rows": [["1"], ["2"]]},
+        {"shape": "table", "lead": "L", "headers": ["a", "b"], "rows": [["1", "2"]]},
+        {"shape": "definition", "lead": "L", "title": "T", "points": [{"term": "a"}]},
+        {"shape": "steps", "lead": "L", "title": "T", "steps": "no es una lista"},
+        {"shape": "steps"},
+        "no es un objeto",
+        None,
+        [],
+    ],
+)
+def test_anything_that_is_not_the_shape_it_claims_falls_back_to_prose(payload) -> None:
+    """No coercion, no second guess. A table with a hole in it is worse than a paragraph."""
+    assert emit_chat_program(payload) is None
+
+
+def test_a_number_where_a_cell_was_asked_for_is_kept_not_blanked() -> None:
+    """Asked for a cell, a model writes ``40`` as often as ``"40"``.
+
+    The first cut of the emitter required ``str`` and turned an all-numeric table into a
+    grid of empty cells — a block that renders, says nothing, and reads as missing data
+    rather than as a failed layout. The worst of the three possible outcomes.
+    """
+    program = emit_chat_program(
+        {"shape": "table", "lead": "L", "headers": ["A", "B"], "rows": [[1, 2], [3, 4]]}
+    )
+    assert program is not None
+    assert '[["1", "2"], ["3", "4"]]' in program
+
+
+def test_an_empty_cell_is_data_and_a_non_scalar_cell_is_a_failure() -> None:
+    """"sin plazo" is a blank cell. ``{"a": 1}`` is a table the model did not populate."""
+    blank = emit_chat_program(
+        {"shape": "table", "lead": "L", "headers": ["A", "B"], "rows": [["x", ""], ["y", "z"]]}
+    )
+    assert blank is not None and '["x", ""]' in blank
+
+    for bad_cell in ({"a": 1}, ["nested"], True, None):
+        assert (
+            emit_chat_program(
+                {
+                    "shape": "table",
+                    "lead": "L",
+                    "headers": ["A", "B"],
+                    "rows": [["x", bad_cell], ["y", "z"]],
+                }
+            )
+            is None
+        )
+
+
+@pytest.mark.parametrize("bad_step", [{"a": 1}, ["nested"], "", "   ", None, True])
+def test_one_unusable_step_kills_the_procedure_instead_of_shortening_it(bad_step) -> None:
+    """Dropping it quietly would serve a three-step procedure as two.
+
+    A wrong answer that looks like a right one is the worst thing this call can produce,
+    and a procedure is where it would hurt most: the missing step is the one nobody knows
+    they skipped.
+    """
+    assert (
+        emit_chat_program(
+            {"shape": "steps", "lead": "L", "title": "T", "steps": [bad_step, "b", "c"]}
+        )
+        is None
+    )
+
+
+def test_a_lead_is_required_unless_the_body_can_fill_the_slot_itself() -> None:
+    """Contract rule 7. A Callout is a legal first child; a StepSequence is not.
+
+    The emitter never writes a lead of its own to satisfy the rule — inventing a sentence
+    is exactly the thing this whole call is forbidden to do.
+    """
+    assert emit_chat_program({"shape": "steps", "title": "T", "steps": ["a", "b"]}) is None
+    callout = emit_chat_program({"shape": "callout", "text": "No sirvas sin comprobarlo"})
+    assert callout is not None
+    assert validate_chat_program(callout) == callout
+
+
+def test_the_failure_classes_the_bench_measured_are_unrepresentable() -> None:
+    """Named arguments, an accented identifier, ``{``, the line cap.
+
+    All four were real rejections in ``bench_out/failures/`` when the model authored the
+    program. Here the model supplies them *as content* and the program is still clean,
+    because the model no longer writes any of the syntax.
+    """
+    program = emit_chat_program(
+        {
+            "shape": "steps",
+            "lead": "Stack(children = [intro], gap = \"md\")",
+            "title": "Conclusión con acento y {llaves}",
+            "steps": ["línea uno\ncon salto", "dos"],
+        }
+    )
+    assert program is not None
+    assert validate_chat_program(program) == program
+    # Three lines, whatever the model wrote: the shape decides the size, not the content.
+    assert program.count("\n") == 3
+    # The newline inside a value became a space rather than an unterminated literal.
+    assert "línea uno con salto" in program
+
+
+# -- no figure survives the layout call that was not in the answer -----------------------
+def test_a_figure_the_answer_never_had_is_caught() -> None:
+    answer = "Lucia va por el 40% (2 de 5 nodos) y Aitana no ha empezado."
+    honest = 'cuerpo = Table(["Quien", "Cuanto"], [["Lucia", "40%"], ["Aitana", "sin empezar"]])'
+    invented = 'cuerpo = Table(["Quien", "Cuanto"], [["Lucia", "60%"], ["Aitana", "0 de 5"]])'
+
+    assert invented_figures(honest, answer) == []
+    # "0" counts too: the answer said "no ha empezado", not "0 de 5".
+    assert invented_figures(invented, answer) == ["0", "60"]
+
+
+def test_the_shape_of_a_figure_does_not_count_against_it() -> None:
+    """"40%" and "40" are the same claim; "2/5" contributes both of its halves."""
+    assert invented_figures('x = TextContent("40", "body")', "va por el 40%") == []
+    assert invented_figures('x = TextContent("2/5", "body")', "2 de 5 nodos") == []
+
+
+def test_a_deadline_invented_between_the_two_calls_never_reaches_the_browser() -> None:
+    """The class of error that matters most here: a plazo that is not in the seed."""
+    answer = "Aitana tiene el curso de Higiene asignado y no lo ha abierto."
+    program = 'cuerpo = Callout("warn", "Aitana debe terminarlo antes del 15/08/2026")'
+    assert invented_figures(program, answer) == ["08", "15", "2026"]
+
+
+async def test_an_invented_figure_costs_the_blocks_and_never_the_answer(monkeypatch) -> None:
+    """End to end: the reader keeps the prose the first call actually produced."""
+    lying = json.dumps(
+        {
+            "shape": "table",
+            "lead": "Asi van.",
+            "headers": ["Empleado", "Avance"],
+            # Nothing in LONG_ANSWER contains 60 or 99.
+            "rows": [["Lucia", "60%"], ["Aitana", "99%"]],
+        }
+    )
+    llm = _FakeLLM(LONG_ANSWER, layout=lying)
+    events, repo = await _run(monkeypatch, llm, generative_ui=True)
+    names = [name for name, _ in events]
+
+    assert llm.completions == 1
+    assert "ui" not in names
+    assert "layout_skipped" in names
+    assert "program" not in repo.messages[-1].message_metadata
+    assert repo.messages[-1].content.strip().startswith("Los alergenos")
+
+
+def test_a_reply_that_is_not_json_is_a_fallback_and_not_a_crash() -> None:
+    for raw in ("", "lo siento", NO_UI_SENTINEL, "{roto", "[1, 2]"):
+        assert emit_chat_program(parse_layout_json(raw)) is None
+
+
+def test_a_fenced_object_is_still_read() -> None:
+    """``json_mode`` is requested, but "mostly honoured" is not a contract."""
+    assert parse_layout_json('```json\n{"shape": "prose"}\n```') == {"shape": "prose"}
+    assert parse_layout_json('Aqui tienes:\n{"shape": "prose"}') == {"shape": "prose"}
 
 
 # -- the stream ---------------------------------------------------------------------
@@ -149,9 +422,12 @@ class _FakeRepo:
 
 
 class _FakeLLM:
-    """Streams ``answer`` token by token, then returns ``layout`` from ``complete``."""
+    """Streams ``answer`` token by token, then returns ``layout`` from ``complete``.
 
-    def __init__(self, answer: str, layout: str = NO_UI_SENTINEL) -> None:
+    ``layout`` is now the *JSON* the classify+populate call returns, not a program.
+    """
+
+    def __init__(self, answer: str, layout: str = PROSE_PAYLOAD) -> None:
         self.answer = answer
         self.layout = layout
         self.completions = 0
@@ -213,7 +489,7 @@ async def test_grounding_is_announced_before_the_first_token(monkeypatch) -> Non
 
 async def test_the_program_arrives_after_done(monkeypatch) -> None:
     """The composer is handed back at ``done``; the blocks are a trailing event."""
-    llm = _FakeLLM(LONG_ANSWER, layout=VALID_PROGRAM)
+    llm = _FakeLLM(LONG_ANSWER, layout=STEPS_PAYLOAD)
     events, repo = await _run(monkeypatch, llm, generative_ui=True)
     names = [name for name, _ in events]
 
@@ -225,8 +501,11 @@ async def test_the_program_arrives_after_done(monkeypatch) -> None:
     assert repo.messages[-1].message_metadata["program"] == program
 
 
-async def test_an_invalid_program_degrades_to_the_prose(monkeypatch) -> None:
-    llm = _FakeLLM(LONG_ANSWER, layout=QUIZ_PROGRAM)
+async def test_an_unusable_shape_degrades_to_the_prose(monkeypatch) -> None:
+    ragged = json.dumps(
+        {"shape": "table", "lead": "L", "headers": ["a", "b"], "rows": [["1"], ["2", "3"]]}
+    )
+    llm = _FakeLLM(LONG_ANSWER, layout=ragged)
     events, repo = await _run(monkeypatch, llm, generative_ui=True)
     names = [name for name, _ in events]
 
@@ -234,6 +513,32 @@ async def test_an_invalid_program_degrades_to_the_prose(monkeypatch) -> None:
     assert "layout_skipped" in names
     assert repo.messages[-1].content.strip().startswith("Los alergenos")
     assert "program" not in repo.messages[-1].message_metadata
+
+
+async def test_a_model_that_answers_with_a_program_gets_the_prose(monkeypatch) -> None:
+    """Belt and braces on the seam: the old output is not JSON, so it is simply refused.
+
+    Worth asserting because a provider ignoring ``json_mode`` and reverting to its old
+    habit must degrade, not half-work.
+    """
+    llm = _FakeLLM(LONG_ANSWER, layout=VALID_PROGRAM)
+    events, _ = await _run(monkeypatch, llm, generative_ui=True)
+
+    assert "ui" not in [name for name, _ in events]
+    assert "layout_skipped" in [name for name, _ in events]
+
+
+async def test_the_layout_call_asks_for_json_mode(monkeypatch) -> None:
+    """Requested on the call, not just hoped for in the prompt."""
+    seen: dict[str, object] = {}
+
+    class _Recording(_FakeLLM):
+        async def complete(self, _system, _user, **kwargs):
+            seen.update(kwargs)
+            return PROSE_PAYLOAD
+
+    await _run(monkeypatch, _Recording(LONG_ANSWER), generative_ui=True)
+    assert seen["json_mode"] is True
 
 
 async def test_a_provider_failure_during_layout_degrades_to_the_prose(monkeypatch) -> None:
@@ -248,7 +553,7 @@ async def test_a_provider_failure_during_layout_degrades_to_the_prose(monkeypatc
 
 async def test_the_flag_off_is_yesterdays_chat(monkeypatch) -> None:
     """v1 with ``DYNAMIC_COURSES_MODE`` off: no second call, no new events."""
-    llm = _FakeLLM(LONG_ANSWER, layout=VALID_PROGRAM)
+    llm = _FakeLLM(LONG_ANSWER, layout=STEPS_PAYLOAD)
     events, _ = await _run(monkeypatch, llm, generative_ui=False)
     names = [name for name, _ in events]
 
@@ -270,10 +575,10 @@ async def test_the_admin_switch_off_costs_nothing_and_reads_the_same(monkeypatch
     generative_ui = chat_route.dynamic_courses_on() and chat_generative_ui_enabled(org_off)
     assert generative_ui is False
 
-    off_llm = _FakeLLM(LONG_ANSWER, layout=VALID_PROGRAM)
+    off_llm = _FakeLLM(LONG_ANSWER, layout=STEPS_PAYLOAD)
     off_events, off_repo = await _run(monkeypatch, off_llm, generative_ui=generative_ui)
 
-    # ...and the same turn where the model simply wrote an unusable program.
+    # ...and the same turn where the model simply returned something unusable.
     rejected_llm = _FakeLLM(LONG_ANSWER, layout="lo siento, no puedo")
     rejected_events, _ = await _run(monkeypatch, rejected_llm, generative_ui=True)
 
@@ -290,6 +595,19 @@ async def test_the_admin_switch_off_costs_nothing_and_reads_the_same(monkeypatch
         )
 
     assert answer(off_events) == answer(rejected_events)
+
+
+def test_the_admin_route_composes_the_switches_the_same_way_the_tutor_route_does() -> None:
+    """The route used to build ``ChatService`` without the flag at all.
+
+    Harmless while ``_should_lay_out`` refused every ``admin`` turn anyway, and the whole
+    feature the moment it stopped: the organization's ``chat_generative_ui`` would have
+    decided nothing on the one surface it was just enabled for. Asserted against the
+    source because both routes must keep reading the same two switches.
+    """
+    source = inspect.getsource(chat_route.admin_chat)
+    assert "dynamic_courses_on() and chat_generative_ui_enabled(org_settings)" in source
+    assert "generative_ui=generative_ui" in source
 
 
 @pytest.mark.parametrize(
@@ -312,7 +630,7 @@ def test_both_switches_have_to_agree(monkeypatch, mode, org_settings, expected) 
 
 
 async def test_a_short_answer_does_not_pay_for_a_second_call(monkeypatch) -> None:
-    llm = _FakeLLM("Si, siempre.", layout=VALID_PROGRAM)
+    llm = _FakeLLM("Si, siempre.", layout=STEPS_PAYLOAD)
     events, _ = await _run(monkeypatch, llm, generative_ui=True)
 
     assert len("Si, siempre.") < MIN_LAYOUT_CHARS
@@ -320,24 +638,66 @@ async def test_a_short_answer_does_not_pay_for_a_second_call(monkeypatch) -> Non
     assert "ui" not in [name for name, _ in events]
 
 
-async def test_the_admin_assistant_never_lays_out(monkeypatch) -> None:
+async def _run_admin_layout(monkeypatch, llm, *, generative_ui: bool):
     async def fake_ground(*_args, **_kwargs):
         return GroundedContext("general")
 
+    async def fake_build(*_args, **_kwargs):
+        raise RuntimeError("no database in this test")
+
     monkeypatch.setattr(chat_module, "ground_question", fake_ground)
-    llm = _FakeLLM(LONG_ANSWER, layout=VALID_PROGRAM)
+    monkeypatch.setattr(chat_module, "build_org_snapshot", fake_build)
     service = ChatService(
         _FakeDB(),  # type: ignore[arg-type]
         llm,  # type: ignore[arg-type]
         object(),  # type: ignore[arg-type]
-        generative_ui=True,
+        generative_ui=generative_ui,
     )
     service.repo = _FakeRepo()  # type: ignore[assignment]
     user = SimpleNamespace(id=uuid.uuid4(), org_id=uuid.uuid4())
-    events = [event async for event in service.stream_admin(user, "cuantos cursos hay", None, None)]
+    return _events(
+        [
+            event
+            async for event in service.stream_admin(user, "como van mis empleados", None, None)
+        ]
+    )
+
+
+async def test_the_admin_assistant_lays_out_too(monkeypatch) -> None:
+    """It used to be excluded. A table of five employees is the clearest case in the app.
+
+    The exclusion was a judgement about answer *length*, and ``MIN_LAYOUT_CHARS`` already
+    makes that judgement on its own — for the admin exactly as for the tutor.
+    """
+    llm = _FakeLLM(ADMIN_ANSWER, layout=TABLE_PAYLOAD)
+    events = await _run_admin_layout(monkeypatch, llm, generative_ui=True)
+    names = [name for name, _ in events]
+
+    assert llm.completions == 1
+    assert names.index("done") < names.index("ui")
+    program = dict(events[names.index("ui")][1])["program"]
+    assert "Table(" in program
+    assert "Lucia Fernandez Vila" in program
+
+
+async def test_the_admin_layout_answers_to_the_same_two_switches(monkeypatch) -> None:
+    """Enabling it for the admin did not give it its own way in."""
+    llm = _FakeLLM(LONG_ANSWER, layout=TABLE_PAYLOAD)
+    events = await _run_admin_layout(monkeypatch, llm, generative_ui=False)
 
     assert llm.completions == 0
-    assert "ui" not in [name for name, _ in _events(events)]
+    assert "ui" not in [name for name, _ in events]
+    assert "layout_start" not in [name for name, _ in events]
+
+
+async def test_the_admin_layout_falls_back_to_prose_like_every_other(monkeypatch) -> None:
+    llm = _FakeLLM(LONG_ANSWER, layout="no soy JSON")
+    events = await _run_admin_layout(monkeypatch, llm, generative_ui=True)
+    names = [name for name, _ in events]
+
+    assert "ui" not in names
+    assert "layout_skipped" in names
+    assert "error" not in names
 
 
 async def test_a_user_with_nothing_still_gets_an_answer(monkeypatch) -> None:

--- a/apps/skillnet-api/tests/test_org_snapshot.py
+++ b/apps/skillnet-api/tests/test_org_snapshot.py
@@ -1,0 +1,382 @@
+"""The admin's snapshot: the arithmetic, the text, and the line it must not cross.
+
+Three groups, and the middle one is the reason the file exists at all.
+
+1. **The facts.** Percentages, overdue deadlines and the completed-means-100% rule.
+2. **The privacy allowlist.** ``learner_profiles`` is private to the employee (its own
+   docstring says so); the admin sees training records and never the declared onboarding
+   answers. That is enforced by reading this module's **AST** and asserting no forbidden
+   column is ever touched, because "nobody added it" is a habit and this is a control.
+3. **The rendering.** The exact bytes that reach the model, including the two things the
+   model cannot infer: that every number is printed, and that a trimmed list says so.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from datetime import date, datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from src.services import org_snapshot as snapshot_module
+from src.services.org_snapshot import (
+    FORBIDDEN_PROFILE_FIELDS,
+    MAX_EMPLOYEES_LISTED,
+    CourseFact,
+    EmployeeFact,
+    EnrolmentFact,
+    OrgSnapshot,
+    render_snapshot,
+)
+
+NOW = datetime(2026, 7, 28, 9, 0, tzinfo=timezone.utc)
+TODAY = NOW.date()
+
+
+def _snapshot(**overrides) -> OrgSnapshot:
+    base = {
+        "org_name": "Panaderia y Cafeteria La Espiga S.L.",
+        "generated_at": NOW,
+        "employees": (),
+        "courses": (),
+        "documents": (),
+        "documents_total": 0,
+        "employees_total": 0,
+    }
+    base.update(overrides)
+    employees = base["employees"]
+    if employees and not base["employees_total"]:
+        base["employees_total"] = len(employees)
+    return OrgSnapshot(**base)  # type: ignore[arg-type]
+
+
+LUCIA = EmployeeFact(
+    full_name="Lucia Fernandez Vila",
+    role_title="Dependiente",
+    hired_on=date(2023, 9, 4),
+    enrolments=(
+        EnrolmentFact(
+            course_title="Alergenos e informacion al cliente",
+            status="in_progress",
+            done=2,
+            total=5,
+            unit="nodos",
+            deadline=date(2026, 8, 15),
+        ),
+        EnrolmentFact(
+            course_title="Manejo de caja",
+            status="assigned",
+            done=0,
+            total=4,
+            unit="lecciones",
+            deadline=date(2026, 7, 1),
+        ),
+    ),
+    skills=(("caja_tpv", "medium"), ("gestion_alergenos", "low")),
+    nodes_mastered=2,
+)
+
+MARCOS = EmployeeFact(
+    full_name="Marcos Iglesias Rey",
+    role_title="Cocinero",
+    enrolments=(
+        EnrolmentFact(
+            course_title="Alergenos e informacion al cliente",
+            status="completed",
+            done=5,
+            total=5,
+            unit="nodos",
+            completed_on=date(2026, 7, 20),
+        ),
+    ),
+    nodes_mastered=5,
+)
+
+
+# -- the facts ----------------------------------------------------------------------
+def test_percent_is_rounded_from_the_counted_units() -> None:
+    assert EnrolmentFact("C", "in_progress", done=2, total=5).percent == 40
+    assert EnrolmentFact("C", "in_progress", done=1, total=3).percent == 33
+
+
+def test_percent_is_none_when_the_course_has_no_units_to_count() -> None:
+    """A course with no lessons and no nodes has no progress, and 0% would be a claim."""
+    assert EnrolmentFact("C", "assigned", done=0, total=0).percent is None
+    assert EnrolmentFact("C", "assigned").percent is None
+
+
+def test_a_past_deadline_is_overdue_until_it_is_completed() -> None:
+    late = EnrolmentFact("C", "in_progress", deadline=date(2026, 7, 1))
+    done = EnrolmentFact("C", "completed", deadline=date(2026, 7, 1))
+
+    assert late.is_overdue(TODAY) is True
+    assert done.is_overdue(TODAY) is False
+
+
+def test_needs_attention_is_overdue_or_never_opened() -> None:
+    assert EnrolmentFact("C", "assigned").needs_attention(TODAY) is True
+    assert EnrolmentFact("C", "in_progress").needs_attention(TODAY) is False
+    assert (
+        EnrolmentFact("C", "in_progress", deadline=date(2020, 1, 1)).needs_attention(TODAY)
+        is True
+    )
+
+
+# -- the privacy allowlist ----------------------------------------------------------
+def _attributes_read_by(module) -> set[str]:
+    """Every ``x.attr`` the module's code touches. Docstrings and prose are not nodes."""
+    tree = ast.parse(inspect.getsource(module))
+    return {node.attr for node in ast.walk(tree) if isinstance(node, ast.Attribute)}
+
+
+@pytest.mark.parametrize("forbidden", sorted(FORBIDDEN_PROFILE_FIELDS))
+def test_the_snapshot_never_reads_a_private_profile_column(forbidden: str) -> None:
+    """``preset``, ``format_vector``, ``accessibility`` and friends are the employee's.
+
+    They are how a person asked to be taught — including reading needs — and naming an
+    individual with them is the disclosure this product's RGPD position rules out (§6).
+    An attribute access is how they would be selected, so an attribute access is what is
+    forbidden; the docstrings above are free to name them, and do.
+    """
+    assert forbidden not in _attributes_read_by(snapshot_module)
+
+
+def test_the_only_profile_column_that_travels_is_the_job_title() -> None:
+    source = inspect.getsource(snapshot_module)
+    accesses = {
+        line.strip()
+        for line in source.splitlines()
+        if "LearnerProfile." in line and not line.strip().startswith("#")
+    }
+    referenced = {
+        access.split("LearnerProfile.")[1].split()[0].strip(",.)")
+        for access in accesses
+    }
+    assert referenced <= {"role_title", "user_id", "org_id"}
+
+
+def test_the_rendered_block_carries_no_private_value() -> None:
+    """Belt and braces: the text itself, not just the queries behind it."""
+    text = render_snapshot(_snapshot(employees=(LUCIA, MARCOS))).lower()
+    for forbidden in ("format_vector", "tutor_notes", "accessibility", "short_blocks"):
+        assert forbidden not in text
+
+
+def test_the_employee_fact_has_no_field_for_a_private_signal() -> None:
+    """The shape is the guarantee: there is nowhere to put one, so none can leak."""
+    assert set(EmployeeFact.__dataclass_fields__) == {
+        "full_name",
+        "role_title",
+        "active",
+        "hired_on",
+        "enrolments",
+        "skills",
+        "nodes_mastered",
+    }
+
+
+# -- the summary the model is forbidden to compute ------------------------------------
+def test_the_totals_are_counted_here_so_the_model_never_adds() -> None:
+    """Without a headline to quote, a small model answers with five name-by-name blocks."""
+    text = render_snapshot(_snapshot(employees=(LUCIA, MARCOS)))
+
+    assert "RESUMEN (ya contado, no lo recalcules)" in text
+    assert "- empleados: 2" in text
+    assert "asignaciones de curso: 3 (1 completadas, 1 en curso, 1 sin empezar)" in text
+
+
+def test_the_summary_names_who_is_late_and_who_never_started() -> None:
+    idle = EmployeeFact(
+        full_name="Noa Pereira Ramos",
+        enrolments=(EnrolmentFact("Alergenos", "assigned", 0, 5, "nodos"),),
+    )
+    text = render_snapshot(_snapshot(employees=(LUCIA, MARCOS, idle)))
+
+    assert "no han empezado NINGUNO de sus cursos: 1 (Noa Pereira Ramos)" in text
+    assert "algun plazo vencido: 1 (Lucia Fernandez Vila)" in text
+    assert "sin ningun curso asignado: 0" in text
+
+
+def test_someone_with_no_courses_is_counted_separately_from_someone_who_stalled() -> None:
+    """"No ha empezado" and "no tiene nada asignado" are different problems."""
+    text = render_snapshot(
+        _snapshot(employees=(EmployeeFact(full_name="Sin Cursos Ninguno"),))
+    )
+    assert "sin ningun curso asignado: 1 (Sin Cursos Ninguno)" in text
+    assert "no han empezado NINGUNO de sus cursos: 0" in text
+
+
+def test_a_long_name_list_is_cut_but_its_count_never_is() -> None:
+    """A truncated list next to a truncated count would be two lies for the price of one."""
+    stalled = tuple(
+        EmployeeFact(
+            full_name=f"Persona {i:02d}",
+            enrolments=(EnrolmentFact("C", "assigned"),),
+        )
+        for i in range(14)
+    )
+    text = render_snapshot(_snapshot(employees=stalled))
+
+    assert "no han empezado NINGUNO de sus cursos: 14 (" in text
+    assert "+4 mas)" in text
+
+
+# -- the rendering ------------------------------------------------------------------
+def test_an_empty_organization_renders_to_nothing() -> None:
+    """No employees, no courses, no documents: no block, and the turn is unchanged."""
+    assert render_snapshot(_snapshot()) == ""
+
+
+def test_every_number_is_printed_so_nothing_has_to_be_computed() -> None:
+    text = render_snapshot(_snapshot(employees=(LUCIA,)))
+
+    assert "Lucia Fernandez Vila (Dependiente)" in text
+    assert "40% (2/5 nodos)" in text
+    assert "0% (0/4 lecciones)" in text
+
+
+def test_an_overdue_deadline_is_shouted_not_left_to_be_worked_out() -> None:
+    text = render_snapshot(_snapshot(employees=(LUCIA,)))
+
+    assert "plazo 2026-07-01 (FUERA DE PLAZO)" in text
+    assert "plazo 2026-08-15 (FUERA DE PLAZO)" not in text
+
+
+def test_a_person_with_no_courses_says_so_rather_than_being_a_blank_line() -> None:
+    text = render_snapshot(
+        _snapshot(employees=(EmployeeFact(full_name="Noa Pereira Ramos"),))
+    )
+    assert "- Noa Pereira Ramos" in text
+    assert "sin cursos asignados" in text
+
+
+def test_skills_are_rendered_in_spanish_levels() -> None:
+    text = render_snapshot(_snapshot(employees=(LUCIA,)))
+    assert "caja_tpv (medio)" in text
+    assert "gestion_alergenos (bajo)" in text
+
+
+def test_courses_carry_their_state_and_their_assignment_counts() -> None:
+    text = render_snapshot(
+        _snapshot(
+            courses=(
+                CourseFact(
+                    title="Alergenos e informacion al cliente",
+                    status="publicado",
+                    delivery="dinamico",
+                    units=5,
+                    unit_name="nodos",
+                    assigned=1,
+                    in_progress=2,
+                    completed=2,
+                ),
+            )
+        )
+    )
+    assert "publicado (dinamico), 5 nodos" in text
+    assert "5 asignaciones (2 completadas, 2 en curso, 1 sin empezar)" in text
+
+
+def test_a_static_course_does_not_say_static_on_every_line() -> None:
+    """On a v1 deployment every course is static, so the word distinguishes nothing."""
+    text = render_snapshot(
+        _snapshot(
+            courses=(
+                CourseFact("Manejo de caja", "publicado", "estatico", 4, "lecciones"),
+            )
+        )
+    )
+    assert "- Manejo de caja: publicado, 4 lecciones" in text
+    assert "estatico" not in text
+
+
+@pytest.mark.parametrize(
+    ("mode", "delivery_mode", "lessons", "nodes", "expected"),
+    [
+        # Served dynamically: measured in nodes, which is what the learner advances in.
+        ("on", "dynamic", 0, 5, ("nodos", "dinamico", 5)),
+        ("on", "dynamic", 3, 5, ("nodos", "dinamico", 5)),
+        # v1, or the flag off: the one decision point puts it on the static path.
+        ("off", "dynamic", 0, 5, ("nodos", "estatico", 5)),
+        ("on", "static", 4, 0, ("lecciones", "estatico", 4)),
+        # Nothing to count at all: no unit, rather than a "0 lecciones" that reads false.
+        ("on", "static", 0, 0, ("", "estatico", 0)),
+    ],
+)
+def test_a_course_is_counted_in_the_unit_it_actually_has(
+    monkeypatch, mode, delivery_mode, lessons, nodes, expected
+) -> None:
+    """A schema-first course has nodes and no lessons; "0 lecciones" would read as empty."""
+    monkeypatch.setattr(snapshot_module.settings, "DYNAMIC_COURSES_MODE", mode)
+    course = SimpleNamespace(delivery_mode=delivery_mode, schema_status="validated")
+
+    assert snapshot_module._units_for(course, lessons=lessons, nodes=nodes) == expected
+
+
+def test_documents_are_titles_only() -> None:
+    text = render_snapshot(
+        _snapshot(documents=("Manual de alergenos",), documents_total=1)
+    )
+    assert "DOCUMENTOS SUBIDOS (1)" in text
+    assert "- Manual de alergenos" in text
+
+
+def test_a_trimmed_list_says_it_is_trimmed_and_keeps_the_urgent_people() -> None:
+    """A truncated list that silently drops the overdue person reads like an all-clear."""
+    calm = tuple(
+        EmployeeFact(
+            full_name=f"Empleado Tranquilo {i:02d}",
+            enrolments=(EnrolmentFact("C", "in_progress", done=1, total=2),),
+        )
+        for i in range(MAX_EMPLOYEES_LISTED + 5)
+    )
+    urgent = EmployeeFact(
+        full_name="Zulema Ultima Alfabeticamente",
+        enrolments=(EnrolmentFact("C", "in_progress", deadline=date(2020, 1, 1)),),
+    )
+    text = render_snapshot(_snapshot(employees=(*calm, urgent)))
+
+    assert f"EMPLEADOS ({MAX_EMPLOYEES_LISTED + 6})" in text
+    assert f"se listan {MAX_EMPLOYEES_LISTED} de {MAX_EMPLOYEES_LISTED + 6}" in text
+    assert "La lista es PARCIAL" in text
+    assert "Zulema Ultima Alfabeticamente" in text
+
+
+def test_a_small_organization_is_never_trimmed_and_never_says_it_was() -> None:
+    text = render_snapshot(_snapshot(employees=(LUCIA, MARCOS)))
+    assert "PARCIAL" not in text
+    assert "EMPLEADOS (2)" in text
+
+
+def test_the_seeded_organization_stays_small_enough_to_paste_every_turn() -> None:
+    """Five employees, three courses: the whole argument against tool-calling, measured."""
+    text = render_snapshot(
+        _snapshot(
+            employees=tuple(
+                EmployeeFact(
+                    full_name=f"Empleado Numero {i}",
+                    role_title="Camarero",
+                    hired_on=date(2024, 1, 1),
+                    enrolments=(
+                        EnrolmentFact("Alergenos", "in_progress", 2, 5, "nodos"),
+                        EnrolmentFact("Sala", "assigned", 0, 4, "nodos"),
+                        EnrolmentFact("Caja", "completed", 6, 6, "lecciones"),
+                    ),
+                    skills=(("atencion_cliente", "medium"),),
+                    nodes_mastered=2,
+                )
+                for i in range(5)
+            ),
+            courses=(
+                CourseFact("Alergenos", "publicado", "dinamico", 5, "nodos", 1, 3, 1),
+                CourseFact("Sala", "publicado", "dinamico", 4, "nodos", 4, 0, 0),
+                CourseFact("Caja", "publicado", "estatico", 6, "lecciones", 0, 0, 4),
+            ),
+            documents=("Manual de alergenos", "Protocolo de sala", "Manejo de caja"),
+            documents_total=3,
+        )
+    )
+    # ~1.5 kB, i.e. well under 500 tokens: cheaper than a single tool round trip.
+    assert len(text) < 2_500

--- a/apps/skillnet-api/tests/test_render_openui.py
+++ b/apps/skillnet-api/tests/test_render_openui.py
@@ -371,6 +371,35 @@ def test_grammar_rule_2_table_rows_must_be_nested() -> None:
     assert "array of arrays" in str(excinfo.value)
 
 
+def test_a_table_row_must_have_one_cell_per_header() -> None:
+    """A table whose rows do not line up with its headers is a broken screen.
+
+    ``STRING_MATRIX`` only checks "list of lists of strings", so this used to be served.
+    Measured on the real ``Los catorce alergenos obligatorios`` node: told to use a single
+    column, the model emitted one row holding all fourteen allergens, which paints as one
+    row running off the side of the screen and which nothing rejected.
+    """
+    raw = (
+        'root = Stack([t], "md")\n'
+        't = Table(["Alergeno"], [["Gluten", "Huevos", "Leche"]])\n'
+    )
+    with pytest.raises(RenderError) as excinfo:
+        BACKEND.parse(raw)
+    message = str(excinfo.value)
+    assert "3 cells but there is 1 header" in message
+    # The message has to show the shape, not just name the mismatch.
+    assert '[["a"], ["b"], ["c"]]' in message
+
+
+def test_a_one_column_table_with_one_cell_per_row_is_accepted() -> None:
+    raw = (
+        'root = Stack([intro, t], "md")\n'
+        'intro = TextContent("Los alergenos de la casa.", "lead")\n'
+        't = Table(["Alergeno"], [["Gluten"], ["Huevos"], ["Leche"]])\n'
+    )
+    assert len(BACKEND.parse(raw).component("t").props["rows"]) == 3
+
+
 def test_grammar_rule_3_a_literal_newline_breaks_the_string() -> None:
     with pytest.raises(RenderParseError) as excinfo:
         BACKEND.parse(_dsl("malformed_literal_newline"))

--- a/apps/skillnet-api/tests/test_runtime_graph.py
+++ b/apps/skillnet-api/tests/test_runtime_graph.py
@@ -1597,13 +1597,76 @@ _REPAIR_BAD = (
 
 
 def test_the_repair_prompt_pairs_every_mistake_with_its_correction() -> None:
-    """A named counterexample beats a rule in prose for a small model (§4.2)."""
+    """A named counterexample beats a rule in prose for a small model (§4.2).
+
+    Counted exactly rather than as ``>= 1``: an unpaired MAL is a counterexample that
+    teaches the mistake and never shows the fix, and it is the kind of thing that survives
+    a careless edit. The repair system prompt is the header **plus the whole generator
+    tail**, so the total spans both — four in the header (the three of ``_REPAIR_BAD`` and
+    the accented id) and one in the tail (SkillNet 17's bare array declaration).
+    """
     system = ui_repair_system()
-    assert system.count("MAL") == len(_REPAIR_BAD) + 1  # + the accented-id one
+    assert system.count("MAL") == len(_REPAIR_BAD) + 2
     assert system.count("BIEN") == system.count("MAL")
     assert "argumentos con nombre" in system
     assert "tilde en el id" in system
     assert "la clave como declaracion" in system
+
+
+def test_the_generator_prompt_forbids_the_two_habits_the_baseline_measured() -> None:
+    """SkillNet 17 and 18, and that they are not merely asserted but demonstrated.
+
+    Both come from the 30-render baseline of 2026-07-28: three rejections of
+    ``expected a component name after '=', found '['`` (a bare ``opciones = [...]``
+    declaration) and five of ``duplicate component id``.
+    """
+    backend = get_render_backend("openui")
+    system = ui_generator_system()
+
+    assert 'opciones = ["A", "B"]' in system
+    assert "Cada id se declara UNA sola vez" in system
+
+    # The MAL half really is refused...
+    with pytest.raises(RenderError):
+        canonicalize(
+            'root = Stack([q1], "md")\n'
+            'opciones = ["A", "B"]\n'
+            'q1 = QuizItem("q1", "test", "apply", "Cual?", opciones)\n',
+            ui_format="exercise",
+            backend=backend,
+        )
+    # ...and the BIEN half really is accepted.
+    spec = backend.parse(
+        'root = Stack([q1], "md")\n'
+        'q1 = QuizItem("q1", "test", "apply", "Cual?", ["A", "B"])\n',
+        ui_format="exercise",
+    )
+    assert spec.root == "root"
+
+
+def test_the_node_criticality_never_travels_as_its_enum_token() -> None:
+    """The largest single failure class of the 2026-07-28 baseline, and its cause.
+
+    Eight renders were refused for ``prop 'tone' must be one of: info, warn, success``
+    having received ``'critical'``, ``'recommended'`` or ``'contextual'`` — the
+    ``NodeCriticality`` values, which the prompt was printing verbatim on a line reading
+    ``- Criticidad: critical``. The model copied the only enum-shaped word it could see
+    into the only enum slot it had. ``SkillNet 16`` forbade it in words and did not stop
+    it; deleting the token did.
+    """
+    for criticality in ("critical", "recommended", "contextual"):
+        prompt = build_ui_prompt(
+            title="T", summary="S", criticality=criticality, ui_format="explanation"
+        )
+        assert f"Criticidad: {criticality}" not in prompt
+        assert criticality not in prompt
+
+    # It still travels — as behaviour, which is the whole point of removing the label.
+    critical = build_ui_prompt(
+        title="T", summary="S", criticality="critical", ui_format="explanation"
+    )
+    assert "obligado cumplimiento" in critical
+    assert 'Callout("warn"' in critical
 
 
 def test_the_repair_prompt_no_longer_teaches_the_one_line_rule() -> None:

--- a/apps/skillnet-api/tests/test_runtime_shape.py
+++ b/apps/skillnet-api/tests/test_runtime_shape.py
@@ -1,0 +1,437 @@
+"""Tests for ``src/agents/runtime/shape.py`` — the content-shape analysis of §4.2.
+
+The suite is organised around the two ways this module can be wrong, and they are not
+equally bad:
+
+* **A missed structure** costs nothing. The prompt falls back to what it said before and
+  the model does what it did before.
+* **An invented structure** is a bad screen. A hint saying "the source gives you five
+  numeric values" when it does not sends the model either to invent them — which
+  ``SkillNet 13`` forbids outright, in a compliance product — or to fight the instruction.
+
+So the false-positive tests below are the load-bearing half, and every threshold in the
+module has one. The texts are the real ones: the briefs of ``scripts/quality_bench.py``
+and the seeded ``Alergenos`` document, not prose written to make a regex pass.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.agents.runtime.shape import (
+    MAX_HINTS,
+    ShapePlan,
+    analyze_shape,
+    focus_on_headings,
+    fold,
+    refine_format,
+)
+
+# --------------------------------------------------------------------------------------
+# The material this module was written for
+# --------------------------------------------------------------------------------------
+
+#: The seeded customer document, spelled the way the real one is: the fourteen allergens
+#: as fourteen short sentences, closed by a long one about which products carry them.
+ALERGENOS_DOC = """\
+Manual de alergenos e informacion al cliente
+
+Marco legal
+
+El Reglamento (UE) 1169/2011 y el Real Decreto 126/2015 obligan a informar de la presencia
+de los catorce alergenos de declaracion obligatoria en cualquier alimento que se sirva sin
+envasar. La responsabilidad de que esa informacion sea correcta es del establecimiento.
+
+Los catorce alergenos de declaracion obligatoria
+
+Cereales con gluten (trigo, centeno, cebada, avena, espelta, kamut). Crustaceos. Huevos.
+Pescado. Cacahuetes. Soja. Leche, incluida la lactosa. Frutos de cascara (almendra,
+avellana, nuez, anacardo, pistacho y similares). Apio. Mostaza. Granos de sesamo. Dioxido
+de azufre y sulfitos en concentraciones superiores a 10 mg/kg. Altramuces. Moluscos. En La
+Espiga, la masa madre, las empanadas y toda la bolleria llevan cereales con gluten.
+
+Contaminacion cruzada en el obrador
+
+La harina de trigo permanece en suspension en el aire hasta veinte minutos despues de
+amasar, asi que un pedido sin gluten no se prepara justo despues de un amasado. Antes de
+elaborar sin gluten se limpian a fondo superficie, amasadora y utensilios.
+"""
+
+#: The same fourteen items written inline, which is how the bench brief spells them. The
+#: module has to find the list in both spellings or it would have missed the one screen it
+#: was written for, depending on which document the customer happened to upload.
+ALERGENOS_INLINE = (
+    "Los 14 alergenos de declaracion obligatoria son: cereales con gluten, crustaceos, "
+    "huevos, pescado, cacahuetes, soja, leche, frutos de cascara, apio, mostaza, granos "
+    "de sesamo, dioxido de azufre y sulfitos, altramuces y moluscos."
+)
+
+TEMPERATURAS = """\
+PLAN DE HIGIENE - CONTROL DE TEMPERATURAS (APPCC)
+
+Temperaturas maximas de conservacion:
+- Camara de refrigerado de carne: 4 grados C
+- Camara de refrigerado de pescado: 2 grados C
+- Camara de lacteos y postres: 6 grados C
+- Congelador: -18 grados C
+- Vitrina de servicio en caliente: 65 grados C minimo
+"""
+
+PROCEDIMIENTO = """\
+Tecnica correcta:
+1. Separar los pies a la anchura de los hombros, uno ligeramente adelantado.
+2. Doblar las rodillas manteniendo la espalda recta, nunca doblar la espalda.
+3. Agarrar la carga firmemente con las dos manos.
+4. Levantar suavemente estirando las piernas, con la carga pegada al cuerpo.
+"""
+
+#: Ordinary compliance prose. Nothing in here is a list, a table or a series, and the whole
+#: point of the thresholds is that this produces no hint at all.
+PROSA = """\
+PROTECCION DE DATOS - INSTRUCCIONES PARA PERSONAL DE ATENCION
+
+Principio de minimizacion. Solo se piden los datos necesarios para la gestion concreta.
+Para una reparacion en garantia hacen falta nombre, telefono y numero de serie: no hace
+falta el DNI ni la fecha de nacimiento.
+
+Consentimiento. Para enviar publicidad hace falta una casilla marcada activamente por el
+cliente. Una casilla premarcada no es consentimiento valido. El consentimiento se puede
+retirar en cualquier momento y hay que atender la retirada en el acto.
+"""
+
+
+# --------------------------------------------------------------------------------------
+# The structures that are really there
+# --------------------------------------------------------------------------------------
+
+
+def test_the_fourteen_allergens_written_as_sentences_are_a_table() -> None:
+    """The screen the owner rejected, from the document the customer actually uploaded."""
+    plan = analyze_shape(source_context=ALERGENOS_DOC)
+
+    assert plan.blocks == ("Table",)
+    signal = plan.signals[0]
+    assert signal.kind == "enumeration"
+    # Fourteen items, and the long closing sentence must not be counted as a fifteenth.
+    assert signal.count == 14
+
+
+def test_the_fourteen_allergens_written_inline_are_the_same_table() -> None:
+    plan = analyze_shape(source_context=ALERGENOS_INLINE)
+
+    assert plan.blocks == ("Table",)
+    assert plan.signals[0].kind == "enumeration"
+
+
+def test_the_enumeration_hint_forbids_both_measured_wrong_answers() -> None:
+    """One paragraph of commas and one block per item are the two failures on record.
+
+    Served: the fourteen allergens as a comma-separated ``TextContent``. Rejected on the
+    bench: 19 components, one per allergen. The hint has to close both, because closing
+    only one is how the model moves from the first failure to the second.
+    """
+    hint = analyze_shape(source_context=ALERGENOS_DOC).hints()[0]
+
+    assert "Table" in hint
+    assert "separados por comas" in hint
+    assert "un bloque por elemento" in hint
+
+
+def test_labelled_rows_with_short_numeric_values_are_a_series() -> None:
+    plan = analyze_shape(source_context=TEMPERATURAS)
+
+    assert plan.signals[0].kind == "numeric_series"
+    assert plan.signals[0].count == 5
+    assert plan.has_numbers is True
+
+
+def test_a_numeric_series_becomes_a_chart_only_on_a_chart_screen() -> None:
+    """Same signal, different block: the kit has both and the format picks."""
+    plan = analyze_shape(source_context=TEMPERATURAS)
+
+    assert "Chart" in plan.hints("chart")[0]
+    assert "Table" in plan.hints("explanation")[0]
+
+
+def test_numbered_lines_are_a_step_sequence() -> None:
+    plan = analyze_shape(source_context=PROCEDIMIENTO)
+
+    assert "StepSequence" in plan.blocks
+    assert plan.signals[0].count == 4
+
+
+def test_a_mnemonic_procedure_is_a_step_sequence() -> None:
+    """``P - ... / A - ... / S - ...`` is the extintor brief's shape."""
+    source = (
+        "Secuencia de uso (regla PAS):\n"
+        "P - Quitar el Pasador de seguridad tirando de la anilla.\n"
+        "A - Apuntar la boquilla a la base de la llama, no a las llamas.\n"
+        "S - Presionar la maneta y barrer en zigzag.\n"
+    )
+
+    plan = analyze_shape(source_context=source)
+
+    assert "StepSequence" in plan.blocks
+
+
+def test_phase_words_are_a_procedure() -> None:
+    source = (
+        "Fase 1 - Escucha. Se deja hablar al cliente hasta el final.\n\n"
+        "Fase 2 - Reformulacion. Se resume lo que ha dicho.\n\n"
+        "Fase 3 - Disculpa por el efecto, no por la culpa.\n\n"
+        "Fase 4 - Compromiso. Toda llamada se cierra con que, quien y cuando.\n"
+    )
+
+    plan = analyze_shape(source_context=source)
+
+    assert "StepSequence" in plan.blocks
+
+
+# --------------------------------------------------------------------------------------
+# The structures that are not there — the half that protects the learner
+# --------------------------------------------------------------------------------------
+
+
+def test_ordinary_prose_produces_no_hint_at_all() -> None:
+    plan = analyze_shape(source_context=PROSA)
+
+    assert not plan
+    assert plan.blocks == ()
+    assert plan.hints() == ()
+
+
+def test_a_colon_inside_a_sentence_is_not_a_table_row() -> None:
+    """``"Factores que agravan el riesgo: ..."`` is a lead-in, not a two-column row.
+
+    Measured while writing the module: without the bullet requirement this text reported a
+    three-row table built out of one sentence and one numbered step.
+    """
+    source = (
+        "5. No girar el tronco con la carga en alto: mover los pies.\n\n"
+        "Factores que agravan el riesgo: carga voluminosa, suelo resbaladizo, giros.\n\n"
+        "La consigna es siempre: avisar, evacuar y solo despues extinguir.\n"
+    )
+
+    kinds = {signal.kind for signal in analyze_shape(source_context=source).signals}
+
+    assert "labelled_list" not in kinds
+
+
+def test_an_incidental_number_in_a_long_value_is_not_a_data_point() -> None:
+    """``epi-taller``: rows whose values are sentences that happen to contain figures.
+
+    ``"Guantes anticorte nivel 5 y proteccion auditiva (85 dB es el limite)"`` has two
+    numbers in it and is not a value anybody can plot. Reported as a series, this brief
+    would have been sent to build a ``Chart`` out of glove ratings.
+    """
+    source = (
+        "Por tarea:\n"
+        "- Amolado y corte: pantalla facial completa, no solo gafas. Guantes anticorte "
+        "nivel 5 y proteccion auditiva (tapones o cascos, 85 dB es el limite).\n"
+        "- Soldadura: pantalla de soldadura con filtro DIN 11, mandil de cuero, polainas "
+        "y guantes largos.\n"
+        "- Manipulacion de quimicos: guantes de nitrilo y gafas de montura integral.\n"
+    )
+
+    plan = analyze_shape(source_context=source)
+
+    assert plan.signals[0].kind == "labelled_list"
+    assert plan.blocks == ("Table",)
+
+
+def test_a_heading_plus_three_short_sentences_is_not_a_list() -> None:
+    """Runs are counted inside a paragraph, so a section opening is not an enumeration."""
+    source = (
+        "MANUAL DE AUTOPROTECCION\n\n"
+        "Tipo de extintor. Los extintores del local son de polvo ABC de 6 kg. Sirven "
+        "para solidos, liquidos y gases. NO se usan sobre equipos electricos en tension "
+        "por encima de 1.000 V ni sobre aceite de freidora, para el que hay una manta.\n"
+    )
+
+    kinds = {signal.kind for signal in analyze_shape(source_context=source).signals}
+
+    assert "enumeration" not in kinds
+
+
+def test_three_commas_are_not_an_enumeration() -> None:
+    """``MIN_ENUM_ITEMS`` is 4: a sentence listing three things is a sentence."""
+    source = "El fondo fijo es de 200 euros: 40 en monedas, 30 en calderilla y 80 en billetes."
+
+    assert not analyze_shape(source_context=source)
+
+
+def test_an_empty_source_is_not_an_error() -> None:
+    assert analyze_shape(source_context="", summary="") == ShapePlan()
+
+
+# --------------------------------------------------------------------------------------
+# Scoping: a shared document must not hand every node the same hint
+# --------------------------------------------------------------------------------------
+
+
+def test_a_node_only_sees_its_own_section() -> None:
+    """A document of <= 5 pages travels whole into every node's prompt.
+
+    All three nodes of the seeded ``Alergenos`` course are handed the same text, so
+    without scoping the cross-contamination node would be told to build a table of
+    fourteen allergens — true of the source it received, and not what that node teaches.
+    """
+    catorce = analyze_shape(
+        source_context=ALERGENOS_DOC,
+        headings=["Los catorce alergenos de declaracion obligatoria", "Marco legal"],
+    )
+    cruzada = analyze_shape(
+        source_context=ALERGENOS_DOC,
+        headings=["Contaminacion cruzada en el obrador"],
+    )
+
+    assert catorce.blocks == ("Table",)
+    assert cruzada.blocks == ()
+
+
+def test_headings_that_match_nothing_fall_back_to_the_whole_source() -> None:
+    """Re-ingestion renames a heading; a hint from too much text beats no hint."""
+    plan = analyze_shape(
+        source_context=ALERGENOS_DOC, headings=["Una seccion que ya no existe"]
+    )
+
+    assert plan.blocks == ("Table",)
+
+
+def test_focus_keeps_the_body_under_the_heading() -> None:
+    scoped = focus_on_headings(ALERGENOS_DOC, ["Contaminacion cruzada en el obrador"])
+
+    assert "harina de trigo permanece en suspension" in scoped
+    assert "Crustaceos" not in scoped
+
+
+def test_focus_matches_regardless_of_accents_and_case() -> None:
+    scoped = focus_on_headings(ALERGENOS_DOC, ["MARCO LEGAL"])
+
+    assert "Reglamento (UE) 1169/2011" in scoped
+
+
+def test_fold_strips_accents_and_case() -> None:
+    assert fold("Contaminación Cruzada") == "contaminacion cruzada"
+
+
+# --------------------------------------------------------------------------------------
+# Budget
+# --------------------------------------------------------------------------------------
+
+
+def test_no_more_hints_than_the_length_budget_allows() -> None:
+    """The screen holds 3-5 blocks, so a third structural instruction cannot be obeyed."""
+    plan = analyze_shape(source_context=TEMPERATURAS + "\n\n" + PROCEDIMIENTO)
+
+    assert len(plan.signals) >= 2
+    assert len(plan.hints()) <= MAX_HINTS
+
+
+def test_a_shape_hint_never_displaces_the_lead_slot() -> None:
+    """Rule 7 and the shape hint must not fight, because rule 7 wins and the render loses.
+
+    Measured end to end on the real ``Los catorce alergenos obligatorios`` node: the model
+    took the hint, opened the screen with the ``Table``, and was refused twice —
+    ``format 'explanation' requires the first child of root to be a TextContent with
+    variant='lead' or a Callout. Got Table`` — then fell back to the seed lesson. The hints
+    are deliberately the last thing in the prompt, so they have to carry the ordering
+    themselves.
+    """
+    from src.llm.prompts.runtime import build_ui_prompt
+
+    plan = analyze_shape(source_context=ALERGENOS_DOC)
+
+    for ui_format in ("explanation", "mixed"):
+        prompt = build_ui_prompt(
+            title="Los catorce alergenos",
+            summary="S",
+            ui_format=ui_format,
+            shape_hints=plan.hints(ui_format),
+        )
+        assert "nunca el primero" in prompt, ui_format
+        assert '"lead"' in prompt, ui_format
+
+    # ``exercise`` has no lead slot (rule 7 does not apply), so the clause stays out.
+    exercise = build_ui_prompt(
+        title="T", summary="S", ui_format="exercise", shape_hints=plan.hints("exercise")
+    )
+    assert "nunca el primero" not in exercise
+
+
+def test_the_repair_turn_repeats_the_shape_and_the_lead_rule() -> None:
+    """The repair is the turn where "those 14 items are one Table" matters most."""
+    from src.llm.prompts.runtime import build_repair_prompt
+
+    plan = analyze_shape(source_context=ALERGENOS_DOC)
+    prompt = build_repair_prompt(
+        previous="root = Stack([t], \"md\")",
+        errors=["rule 4: a spec holds at most 12 blocks (got 19)"],
+        ui_format="explanation",
+        shape_hints=plan.hints("explanation"),
+    )
+
+    assert "Table" in prompt
+    assert "nunca el primero" in prompt
+
+
+def test_the_same_rows_are_never_reported_twice() -> None:
+    """A numeric series *is* a labelled list; naming both would spend the budget twice."""
+    kinds = [signal.kind for signal in analyze_shape(source_context=TEMPERATURAS).signals]
+
+    assert kinds.count("numeric_series") + kinds.count("labelled_list") == 1
+
+
+# --------------------------------------------------------------------------------------
+# refine_format: the two cases a hand-written default cannot survive
+# --------------------------------------------------------------------------------------
+
+
+def test_a_chart_over_a_source_with_no_figures_becomes_an_explanation() -> None:
+    """The seeded ``Coordinacion con cocina y tiempos`` node, exactly.
+
+    It is declared ``chart`` and its section writes every number as a word — "doce
+    minutos", "dieciocho", "cinco minutos". There is not one digit to plot, so the
+    generator could only have invented the series, which ``SkillNet 13`` forbids. Nothing
+    caught this during calibration because nothing read the source.
+    """
+    source = (
+        "El tiempo objetivo de salida es de doce minutos para los primeros y dieciocho "
+        "para los segundos. Si cocina se retrasa mas de cinco minutos, se avisa a la mesa."
+    )
+    plan = analyze_shape(source_context=source)
+
+    ui_format, reason = refine_format("chart", plan, criticality="recommended")
+
+    assert ui_format == "explanation"
+    assert "cifras" in reason
+
+
+def test_a_critical_node_is_never_served_as_a_chart_alone() -> None:
+    plan = analyze_shape(source_context=TEMPERATURAS)
+
+    ui_format, reason = refine_format("chart", plan, criticality="critical")
+
+    assert ui_format == "explanation"
+    assert "critical" in reason
+
+
+def test_a_chart_with_real_figures_is_left_alone() -> None:
+    plan = analyze_shape(source_context=TEMPERATURAS)
+
+    assert refine_format("chart", plan, criticality="recommended") == ("chart", "")
+
+
+@pytest.mark.parametrize("declared", ["explanation", "exercise", "mixed"])
+def test_every_other_declared_format_is_left_exactly_as_the_creator_wrote_it(
+    declared: str,
+) -> None:
+    """The narrowness is the design.
+
+    The screen the owner rejected was a *correct* ``explanation`` built out of the wrong
+    blocks, so re-deriving the format would have churned the ``cache_key`` of every seeded
+    node without fixing anything. Blocks are the knob; format is not.
+    """
+    plan = analyze_shape(source_context=ALERGENOS_DOC)
+
+    assert refine_format(declared, plan, criticality="critical") == (declared, "")

--- a/apps/skillnet-web/src/api/chat.ts
+++ b/apps/skillnet-web/src/api/chat.ts
@@ -9,6 +9,12 @@ import type {
   Citation,
 } from '../types'
 
+/**
+ * Which assistant answers — and nothing else. The two endpoints speak the *same* SSE
+ * dialect, so there is deliberately one parser below rather than a branch: `ui`
+ * included, now that `_should_lay_out` lays out `admin` turns too. A second handler
+ * for the admin stream is how the `ui` event would get silently dropped on one surface.
+ */
 type ChatEndpoint = '/chat' | '/chat/admin'
 
 /**
@@ -158,6 +164,9 @@ export function useChat(endpoint: ChatEndpoint = '/chat') {
                   ),
                 )
               }
+              // An event type no branch claims falls straight through, on purpose:
+              // `org_data` ships on admin turns today and costs the browser nothing
+              // until somebody decides what, if anything, it should look like.
 
               eventType = ''
             }

--- a/apps/skillnet-web/src/components/chat/ChatAnswer.test.tsx
+++ b/apps/skillnet-web/src/components/chat/ChatAnswer.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ChatAnswer } from './ChatAnswer'
+import { ChatMarkdown } from './ChatMarkdown'
+import type { ChatMessage } from '../../types'
+
+/**
+ * The bubble, from the angle the unit tests were blind to.
+ *
+ * The regression that shipped is instructive: `api/chat.ts` was fully covered, the
+ * `ui` event was parsed correctly, `program` landed on the message — and the screen
+ * was still wrong, because nothing asserted what the *bubble* did with either half of
+ * the answer. So the three claims here are all about pixels, not state:
+ *
+ * 1. Prose is **rendered as markdown**. `**Escucha**` reaching the DOM as four literal
+ *    characters is the reported bug, and it is invisible to any test that only reads
+ *    `message.content`.
+ * 2. The program **replaces** the prose. Not "is also present": the prose must be gone.
+ * 3. A program the browser's gate refuses falls back to the prose. This is the case
+ *    that turns a stricter client gate into a blank bubble, and the server cannot
+ *    prevent it — its validator and this one are deliberately not the same check.
+ */
+
+const PROGRAM = [
+  'root = Stack([intro, pasos], "md")',
+  'intro = TextContent("Consulta siempre la ficha del producto.", "lead")',
+  'pasos = StepSequence("Atender una consulta de alergenos", ["Escucha la pregunta", "Consulta la ficha"])',
+].join('\n')
+
+/** Reactivity: what the gate exists to refuse, and what the server would never emit. */
+const REACTIVE_PROGRAM = [
+  'root = Stack([intro], "md")',
+  'intro = TextContent("Texto", "lead")',
+  'z = Query("leak_everything", {})',
+].join('\n')
+
+const PROSE = [
+  'Para atender una consulta de alergenos:',
+  '',
+  '1. **Escucha la pregunta** del cliente.',
+  '2. *Nunca* improvises.',
+  '',
+  '| Turno | Responsable |',
+  '| --- | --- |',
+  '| Mañana | Noa |',
+].join('\n')
+
+function answer(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'a1',
+    role: 'assistant',
+    content: PROSE,
+    grounding: 'document',
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('ChatAnswer', () => {
+  it('renders the prose as markdown, not as the characters the model typed', () => {
+    const { container } = render(<ChatAnswer message={answer()} />)
+
+    // The literal source must not survive anywhere in the bubble's text.
+    expect(container.textContent).not.toContain('**Escucha')
+    expect(container.textContent).not.toContain('| Turno |')
+
+    expect(screen.getByText('Escucha la pregunta').tagName).toBe('STRONG')
+    expect(screen.getByText('Nunca').tagName).toBe('EM')
+    expect(container.querySelector('ol')).not.toBeNull()
+    // GFM: the table only exists because `remark-gfm` is applied.
+    expect(container.querySelector('table')).not.toBeNull()
+    expect(screen.getByText('Responsable').tagName).toBe('TH')
+  })
+
+  it('lets the kit program replace the prose once it arrives', () => {
+    const { container, rerender } = render(<ChatAnswer message={answer()} />)
+    expect(screen.getByText('Escucha la pregunta').tagName).toBe('STRONG')
+
+    rerender(<ChatAnswer message={answer({ program: PROGRAM })} />)
+
+    // The blocks are the answer. `textContent` rather than `getByText` because §8.5
+    // splits every kit string into per-word spans for the explain popover.
+    expect(container.textContent).toContain('Atender una consulta de alergenos')
+    expect(container.textContent).toContain('Consulta siempre la ficha del producto.')
+    expect(container.querySelector('[data-ui-format="explanation"]')).not.toBeNull()
+    // A StepSequence, which is the shape the question asked for.
+    expect(container.querySelectorAll('ol > li')).toHaveLength(2)
+    // ...and the prose is gone rather than pushed underneath them.
+    expect(container.textContent).not.toContain('Nunca')
+    expect(container.querySelector('table')).toBeNull()
+  })
+
+  it('keeps the prose when the browser gate refuses the program', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { container } = render(<ChatAnswer message={answer({ program: REACTIVE_PROGRAM })} />)
+
+    // Not a blank bubble: the answer the learner was already reading is still there.
+    expect(screen.getByText('Escucha la pregunta').tagName).toBe('STRONG')
+    expect(container.querySelector('[data-ui-format]')).toBeNull()
+    expect(container.textContent).not.toContain('Texto')
+  })
+
+  it('shows the caret while tokens arrive and drops it at done', () => {
+    const { container, rerender } = render(
+      <ChatAnswer message={answer({ content: 'Los alergenos', isStreaming: true })} />,
+    )
+    expect(container.textContent).toContain('▍')
+
+    rerender(<ChatAnswer message={answer({ content: 'Los alergenos son 14.' })} />)
+    expect(container.textContent).not.toContain('▍')
+    expect(container.textContent).toContain('Los alergenos son 14.')
+  })
+
+  it('says it is writing before the first token', () => {
+    render(<ChatAnswer message={answer({ content: '', isStreaming: true })} />)
+    expect(screen.getByText('Escribiendo...')).toBeInTheDocument()
+  })
+})
+
+describe('ChatMarkdown', () => {
+  it('leaves a one-paragraph answer without a trailing margin', () => {
+    const { container } = render(<ChatMarkdown content="Los alergenos son 14." />)
+    const p = container.querySelector('p')
+    expect(p).not.toBeNull()
+    // `last:mb-0` is what keeps the common case pixel-identical to the plain <p> it
+    // replaced; without it every short answer grows a gap inside its own bubble.
+    expect(p?.className).toContain('last:mb-0')
+  })
+
+  it('does not paint an image the model asked for', () => {
+    const { container } = render(
+      <ChatMarkdown content="Mira esto ![pixel](https://tracker.example/p.gif) y ya." />,
+    )
+    // An image is the one construct that calls out to an arbitrary host unattended,
+    // and this text is downstream of a document anybody can upload.
+    expect(container.querySelector('img')).toBeNull()
+    expect(container.textContent).toContain('Mira esto')
+    expect(container.textContent).toContain('y ya.')
+  })
+
+  it('does not let raw HTML out of the text', () => {
+    const { container } = render(
+      <ChatMarkdown content={'Cuidado <script>alert(1)</script> y <b>esto</b>.'} />,
+    )
+    expect(container.querySelector('script')).toBeNull()
+    expect(container.querySelector('b')).toBeNull()
+    expect(container.textContent).toContain('<b>esto</b>')
+  })
+})

--- a/apps/skillnet-web/src/components/chat/ChatAnswer.tsx
+++ b/apps/skillnet-web/src/components/chat/ChatAnswer.tsx
@@ -1,0 +1,82 @@
+import { useMemo, useRef } from 'react'
+import { UiSpecRenderer } from '../courses/UiSpecRenderer'
+import { gateProgram } from '../courses/kit'
+import { ChatMarkdown } from './ChatMarkdown'
+import type { ChatMessage } from '../../types'
+
+/** `ui_format` the tutor lays chat answers out in — `CHAT_UI_FORMAT` in `chat_service.py`. */
+const CHAT_UI_FORMAT = 'explanation'
+
+export interface ChatAnswerProps {
+  message: ChatMessage
+}
+
+/**
+ * One assistant answer: the kit program if there is one, the prose if there is not.
+ *
+ * ## Two beats, one bubble
+ *
+ * The tutor answers twice over the same connection (`api/chat.ts`): prose first, and
+ * then — for an answer long enough to earn a second call — the *same* answer
+ * re-expressed in the SkillNet kit. `done` fires between the two on purpose, so the
+ * composer comes back while the layout is still being produced.
+ *
+ * The prose is therefore the **streaming phase**, not a second copy of the answer. It
+ * is what the learner reads for the two seconds the layout takes, and it stops
+ * existing the moment blocks can take its place. Rendering both would say the tutor
+ * answered twice; rendering blocks *under* the prose would make the bubble grow past
+ * the viewport at the exact moment the learner finished reading it.
+ *
+ * ## Why the program is gated here and not only inside `UiSpecRenderer`
+ *
+ * Because `UiSpecRenderer` answers "may this be painted?" with `null`, and `null` in a
+ * chat bubble is not a degraded answer — it is a **blank bubble**, with the prose
+ * already thrown away. The server validating a program is not enough to rule that out:
+ * the browser's gate is deliberately the stricter of the two (it unions two parsers
+ * that disagree on duplicate ids, caps the *painted* element count rather than the
+ * statement count, and fails closed on a parse exception), so a server-valid program
+ * can still be refused here. Asking the gate first turns every one of those cases back
+ * into the prose the learner was already reading.
+ *
+ * Both gate passes are `useMemo`'d on the same string and the parser is pure, so this
+ * costs one extra parse of ~1 KB, once, on the frame the program lands.
+ */
+export function ChatAnswer({ message }: ChatAnswerProps) {
+  const gate = useMemo(() => gateProgram(message.program), [message.program])
+  const showBlocks = Boolean(message.program) && !gate.blocked && !gate.empty
+
+  /**
+   * Did the learner watch the prose, or was the program already there on the first
+   * frame? Same distinction `NodeView` draws with `viewingHeld`, and for the same
+   * reason: blocks that replace something the learner was reading should resolve in;
+   * a bubble rehydrated from history with its program attached must paint at once,
+   * because animating on load is the anti-pattern the motion system names outright.
+   *
+   * `StackBlock` is what consumes this, and it already drops the stagger for
+   * `useReducedMotion()` — OS setting *or* the preference declared in the wizard.
+   */
+  const watchedProse = useRef(!message.program)
+
+  if (showBlocks) {
+    return (
+      <UiSpecRenderer
+        program={message.program ?? null}
+        // No node owns a chat answer, and no `renderId` either: the layout prompt
+        // cannot emit `QuizItem`, and one that appeared anyway must render read-only
+        // rather than post an attempt against a node the learner is not in.
+        nodeId=""
+        format={CHAT_UI_FORMAT}
+        arriving={watchedProse.current}
+      />
+    )
+  }
+
+  return (
+    <>
+      <ChatMarkdown content={message.content} isStreaming={message.isStreaming} />
+      {message.isStreaming && !message.content && (
+        <p className="text-text-muted">Escribiendo...</p>
+      )}
+    </>
+  )
+}

--- a/apps/skillnet-web/src/components/chat/ChatMarkdown.tsx
+++ b/apps/skillnet-web/src/components/chat/ChatMarkdown.tsx
@@ -1,0 +1,150 @@
+import { memo } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import type { Components } from 'react-markdown'
+
+/**
+ * The caret, as a character rather than an element.
+ *
+ * A `<span>` cannot be appended *inside* the last paragraph of a markdown tree
+ * without knowing which node is last, and "last" changes on every token — it is a
+ * `<p>` one moment and an `<li>` inside a `<ul>` the next. Appending the glyph to
+ * the markdown **source** puts it exactly where the text ends, in whatever element
+ * the parser happens to be building, including a table cell.
+ *
+ * It is also why the old `animate-pulse` caret is gone, which is a small win: it
+ * animated unconditionally, ignoring `useReducedMotion` (OS *or* declared), and a
+ * blinking bar is precisely the kind of motion a learner switches off.
+ */
+const CARET = '▍'
+
+/**
+ * Chat-bubble markdown.
+ *
+ * ## Why this is not `LessonContent`
+ *
+ * `LessonContent` is the *lesson* map: `text-secondary` body, 24 px heading rhythm,
+ * `mb-3` under every block. Dropped into a bubble it reads as a document someone
+ * pasted into a chat — washed out against `bg-bg-muted`, and with a trailing margin
+ * the bubble's own padding then doubles. This map is the same idea at bubble scale:
+ * colour inherited from the bubble, tighter rhythm, and **no margin under the last
+ * child**, so the overwhelmingly common one-paragraph answer is pixel-identical to
+ * the plain `<p>` it replaces. Only the answers that actually use markdown change.
+ *
+ * ## Why markdown is rendered while the answer is still streaming
+ *
+ * Because the half-written state is the state the learner spends the most time
+ * looking at. Deferring the parse to `done` would show `1. **Escucha la pregunta**`
+ * as literal asterisks for the whole stream and then snap — which is the reported
+ * bug, just shorter. remark re-parses a ~1 KB document per token; measured on the
+ * real 278-token answer that is not visible next to React's own re-render.
+ *
+ * ## What is deliberately not rendered
+ *
+ * No `rehype-raw`, so HTML in the model's output stays inert text — the default, and
+ * it stays the default. `img` is disallowed on top of that: an image is the one
+ * markdown construct that makes an unattended request to an arbitrary host the
+ * moment it paints, and this text is downstream of a document anybody can upload.
+ * `href` is left to react-markdown's own URL transform, which already drops
+ * `javascript:`.
+ */
+const components: Components = {
+  p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
+
+  // Chat answers are not documents: every heading level collapses onto one step of
+  // emphasis rather than opening a hierarchy inside a 70%-wide bubble.
+  h1: ({ children }) => <p className="font-semibold mt-3 mb-1.5 first:mt-0">{children}</p>,
+  h2: ({ children }) => <p className="font-semibold mt-3 mb-1.5 first:mt-0">{children}</p>,
+  h3: ({ children }) => <p className="font-semibold mt-3 mb-1.5 first:mt-0">{children}</p>,
+  h4: ({ children }) => <p className="font-semibold mt-3 mb-1.5 first:mt-0">{children}</p>,
+  h5: ({ children }) => <p className="font-semibold mt-3 mb-1.5 first:mt-0">{children}</p>,
+  h6: ({ children }) => <p className="font-semibold mt-3 mb-1.5 first:mt-0">{children}</p>,
+
+  ul: ({ children }) => (
+    <ul className="list-disc pl-5 space-y-1 mb-2 last:mb-0 marker:text-text-muted">{children}</ul>
+  ),
+  ol: ({ children }) => (
+    <ol className="list-decimal pl-5 space-y-1 mb-2 last:mb-0 marker:text-text-muted">
+      {children}
+    </ol>
+  ),
+  li: ({ children }) => <li className="leading-relaxed">{children}</li>,
+
+  strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+  em: ({ children }) => <em className="italic">{children}</em>,
+  del: ({ children }) => <del className="opacity-70">{children}</del>,
+
+  a: ({ children, href }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className="underline underline-offset-2 hover:opacity-80"
+    >
+      {children}
+    </a>
+  ),
+
+  blockquote: ({ children }) => (
+    <blockquote className="border-l-2 border-border-strong pl-3 italic mb-2 last:mb-0">
+      {children}
+    </blockquote>
+  ),
+
+  code: ({ children }) => (
+    <code className="rounded bg-bg px-1 py-0.5 text-[0.9em] font-mono">{children}</code>
+  ),
+  // The inline pill above is neutralised inside a fence rather than branched on:
+  // react-markdown ≥ 9 no longer tells the `code` renderer whether it is inline, and
+  // a fence with no language has no `className` to sniff either.
+  pre: ({ children }) => (
+    <pre className="rounded-lg bg-bg p-2.5 mb-2 last:mb-0 overflow-x-auto text-xs font-mono [&_code]:bg-transparent [&_code]:p-0 [&_code]:text-[1em]">
+      {children}
+    </pre>
+  ),
+
+  // A bubble is 70% of a column: a table has to be allowed to scroll on its own
+  // rather than widen its parent, which is the one thing a chat log must never do.
+  table: ({ children }) => (
+    <div className="overflow-x-auto mb-2 last:mb-0">
+      <table className="w-full text-xs border-collapse">{children}</table>
+    </div>
+  ),
+  th: ({ children }) => (
+    <th className="text-left py-1.5 px-2 border-b border-border-strong font-medium whitespace-nowrap">
+      {children}
+    </th>
+  ),
+  td: ({ children }) => <td className="py-1.5 px-2 border-b border-border align-top">{children}</td>,
+
+  hr: () => <hr className="border-border my-3" />,
+}
+
+export interface ChatMarkdownProps {
+  /** The assistant's prose, as the model wrote it. */
+  content: string
+  /** Appends the caret while tokens are still arriving. */
+  isStreaming?: boolean
+}
+
+/**
+ * `memo` because the bubble re-renders on every token of *any* message in the log,
+ * and only the one whose `content` grew needs to re-parse.
+ */
+export const ChatMarkdown = memo(function ChatMarkdown({
+  content,
+  isStreaming = false,
+}: ChatMarkdownProps) {
+  return (
+    <div className="min-w-0 break-words">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={components}
+        disallowedElements={['img']}
+        unwrapDisallowed
+      >
+        {isStreaming ? `${content}${CARET}` : content}
+      </ReactMarkdown>
+    </div>
+  )
+})

--- a/apps/skillnet-web/src/components/chat/index.ts
+++ b/apps/skillnet-web/src/components/chat/index.ts
@@ -1,0 +1,2 @@
+export { ChatAnswer } from './ChatAnswer'
+export { ChatMarkdown } from './ChatMarkdown'

--- a/apps/skillnet-web/src/components/layout/AdminLayout.tsx
+++ b/apps/skillnet-web/src/components/layout/AdminLayout.tsx
@@ -21,7 +21,10 @@ function AdminLayoutInner() {
       >
         <Header />
 
-        <main className="flex-1 mt-[50px] bg-bg md:rounded-tl-xl overflow-y-auto overflow-x-hidden">
+        {/* No `overflow-y-auto` — see the note in AppLayout. This grows with its content
+            and the page scrolls; the sidebar and header are both `fixed`, so nothing here
+            needed a scroll box of its own. */}
+        <main className="flex-1 mt-[50px] bg-bg md:rounded-tl-xl overflow-x-hidden">
           <ErrorBoundary
             fallback={(error, reset) => (
               <div className="p-4 md:p-6">

--- a/apps/skillnet-web/src/components/layout/AdminLayout.tsx
+++ b/apps/skillnet-web/src/components/layout/AdminLayout.tsx
@@ -23,8 +23,9 @@ function AdminLayoutInner() {
 
         {/* No `overflow-y-auto` — see the note in AppLayout. This grows with its content
             and the page scrolls; the sidebar and header are both `fixed`, so nothing here
-            needed a scroll box of its own. */}
-        <main className="flex-1 mt-[50px] bg-bg md:rounded-tl-xl overflow-x-hidden">
+            needed a scroll box of its own. `clip` rather than `hidden` because
+            `overflow-x: hidden` would force the vertical axis back to `auto`. */}
+        <main className="flex-1 mt-[50px] bg-bg md:rounded-tl-xl overflow-x-clip">
           <ErrorBoundary
             fallback={(error, reset) => (
               <div className="p-4 md:p-6">

--- a/apps/skillnet-web/src/components/layout/AppLayout.tsx
+++ b/apps/skillnet-web/src/components/layout/AppLayout.tsx
@@ -26,9 +26,11 @@ function AppLayoutInner() {
             layout — most obvious on Empleados, where a long list scrolled inside a panel
             while the window stayed still. Nothing needed it: the sidebar is
             `fixed left-0 top-0 bottom-0` and the header is `fixed top-0`, so both stay
-            put under page scroll on their own. `overflow-x-hidden` stays, to stop a wide
-            child blowing out the layout sideways. */}
-        <main className="flex-1 mt-[50px] bg-bg md:rounded-tl-xl overflow-x-hidden">
+            put under page scroll on their own. `overflow-x-clip` and not `hidden`: per spec,
+            `overflow-x: hidden` forces the other axis from `visible` to `auto`, which
+            would quietly recreate the scroll container we just removed. `clip` does
+            not, and still stops a wide child blowing out the layout sideways. */}
+        <main className="flex-1 mt-[50px] bg-bg md:rounded-tl-xl overflow-x-clip">
           <ErrorBoundary
             fallback={(error, reset) => (
               <div className="p-4 md:p-6">

--- a/apps/skillnet-web/src/components/layout/AppLayout.tsx
+++ b/apps/skillnet-web/src/components/layout/AppLayout.tsx
@@ -21,7 +21,14 @@ function AppLayoutInner() {
       >
         <Header />
 
-        <main className="flex-1 mt-[50px] bg-bg md:rounded-tl-xl overflow-y-auto overflow-x-hidden">
+        {/* No `overflow-y-auto`: this element grows with its content and the *page*
+            scrolls. It used to be a scroll box, which put a second scrollbar inside the
+            layout — most obvious on Empleados, where a long list scrolled inside a panel
+            while the window stayed still. Nothing needed it: the sidebar is
+            `fixed left-0 top-0 bottom-0` and the header is `fixed top-0`, so both stay
+            put under page scroll on their own. `overflow-x-hidden` stays, to stop a wide
+            child blowing out the layout sideways. */}
+        <main className="flex-1 mt-[50px] bg-bg md:rounded-tl-xl overflow-x-hidden">
           <ErrorBoundary
             fallback={(error, reset) => (
               <div className="p-4 md:p-6">

--- a/apps/skillnet-web/src/index.css
+++ b/apps/skillnet-web/src/index.css
@@ -253,6 +253,54 @@ body {
   }
 }
 
+/* ── Scrollbars ──────────────────────────────────────────────
+   Global rather than a utility class, because there are 18 scroll containers in the app
+   and the one thing worse than an unstyled scrollbar is half of them being styled. The
+   default Windows/Chromium bar is a wide grey slab that reads as a browser artefact
+   dropped into the page — most visible in the employees table, which scrolls sideways.
+
+   `scrollbar-gutter: stable` on the scrollable elements themselves, not on `html`: it
+   reserves the track so content does not shift by ~12px the moment a list grows past its
+   container, which is the jump you see when a table gains one row.
+
+   Deliberately not on `body`: the L-frame gradient owns that edge. */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border-strong) transparent;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: var(--color-border-strong);
+  border-radius: 9999px;
+  /* Transparent border + background-clip is the only way to inset a webkit thumb, so it
+     floats in the track instead of filling it wall to wall. */
+  border: 3px solid transparent;
+  background-clip: padding-box;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background-color: var(--color-text-muted);
+}
+
+::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+.overflow-x-auto,
+.overflow-y-auto,
+.overflow-auto {
+  scrollbar-gutter: stable;
+}
+
 /* L-frame gradient + cobweb texture */
 .frame-surface {
   background:

--- a/apps/skillnet-web/src/index.css
+++ b/apps/skillnet-web/src/index.css
@@ -301,6 +301,25 @@ body {
   scrollbar-gutter: stable;
 }
 
+/* And the page, which is now a scroll container too.
+   `main` used to be `overflow-y-auto`, so it matched the rule above and its gutter was
+   always reserved — the bar could come and go without moving anything. Moving the
+   scroll to the page (see the note on `<main>` in AppLayout) moved it off that rule and
+   onto `html`, which reserved nothing, so the 10px bar started appearing and
+   disappearing on the window itself as content loaded.
+   That is not just a bar flickering: every appearance narrows the content box by 10px.
+   Measured on /admin/contenido at 1440x920 — `main` goes 1192px → 1182px the moment the
+   courses land, the cards re-wrap in the narrower box and gain ~44px of height, which
+   deepens the overflow that caused it. Reserving the gutter here costs a 10px strip the
+   canvas gradient already paints over, and keeps the page width constant whether or not
+   it scrolls, so nothing reflows when the bar arrives.
+   On `html` and not `body` for the same reason the rule above skips `body`: the L-frame
+   gradient owns that edge, and `body` is not the scroll container — the viewport is, and
+   it takes this from the root element. */
+html {
+  scrollbar-gutter: stable;
+}
+
 /* L-frame gradient + cobweb texture */
 .frame-surface {
   background:

--- a/apps/skillnet-web/src/pages/admin/Chat.test.tsx
+++ b/apps/skillnet-web/src/pages/admin/Chat.test.tsx
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { AdminChat } from './Chat'
+
+/**
+ * The admin assistant as a *screen*, driven by the bytes the server really sends.
+ *
+ * This surface used to render `ChatMarkdown` directly, on the grounds that
+ * `_should_lay_out` in `chat_service.py` excluded `admin` turns outright. That
+ * exclusion is gone: an admin turn now emits a `ui` event exactly like a tutor turn,
+ * and the strongest case for blocks in the whole product lives here — *"como van mis
+ * empleados"* is five people and four columns, which is a table in every other tool
+ * an administrator uses.
+ *
+ * `api/chat.ts` never needed a change for that (one hook, one parser, the endpoint is
+ * only a URL fragment) — which is precisely the failure mode this file exists to
+ * catch. The `ui` event landing on the message object was already true while the
+ * bubble threw it away, so every assertion below reads the DOM after a full SSE turn.
+ */
+
+const mockFetch = vi.fn()
+
+/** The shape the question asks for: an admin turn that earns a table. */
+const PROGRAM = [
+  'root = Stack([intro, tabla], "md")',
+  'intro = TextContent("Tres de cinco empleados van con retraso.", "lead")',
+  'tabla = Table(["Empleado", "Curso", "Progreso"], [["Noa", "Alergenos", "80%"], ["Iker", "Alergenos", "20%"]])',
+].join('\n')
+
+/** What the gate exists to refuse, and what the server would never emit. */
+const REACTIVE_PROGRAM = [
+  'root = Stack([intro], "md")',
+  'intro = TextContent("Datos del equipo", "lead")',
+  'z = Query("leak_everything", {})',
+].join('\n')
+
+/** Real admin output: markdown, because that is what the prompt produces. */
+const PROSE = [
+  'Asi va tu equipo ahora mismo:',
+  '',
+  '- **Noa** va por el 80% de Alergenos.',
+  '- *Iker* se ha quedado en el 20%.',
+].join('\n')
+
+function event(type: string, data: unknown) {
+  return `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`
+}
+
+function tokens(text: string) {
+  return (text.match(/\S+\s*/g) ?? []).map((chunk) => event('token', { content: chunk }))
+}
+
+/**
+ * `frames` stream immediately; `tail` is held until the returned function is called.
+ *
+ * The layout call takes real seconds against a real provider, and that gap is where
+ * the interesting states live — the composer is already back, the notice is up, the
+ * program has not landed. Holding it makes those states assertable instead of a race
+ * against the reader draining and clearing `isLayingOut` on its own.
+ */
+function stream(frames: string[], tail: string[] = []) {
+  const encoder = new TextEncoder()
+  let release: () => void = () => {}
+  const held = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  let index = 0
+  mockFetch.mockImplementation(() =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      body: {
+        getReader: () => ({
+          read: async () => {
+            if (index < frames.length) {
+              return { done: false, value: encoder.encode(frames[index++]) }
+            }
+            if (tail.length > 0 && index === frames.length) {
+              await held
+              index += 1
+              return { done: false, value: encoder.encode(tail.join('')) }
+            }
+            return { done: true, value: undefined }
+          },
+        }),
+      },
+    }),
+  )
+  return () => release()
+}
+
+async function ask(question = 'como van mis empleados') {
+  const user = userEvent.setup()
+  await user.type(screen.getByPlaceholderText(/consulta/i), question)
+  await user.keyboard('{Enter}')
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  vi.stubGlobal('fetch', mockFetch)
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('admin Chat', () => {
+  it('replaces the prose with the kit program when the layout lands', async () => {
+    const release = stream(
+      [
+        event('grounding', { grounding: 'document' }),
+        event('org_data', {
+          employees: 5,
+          courses: 2,
+          documents: 9,
+          generated_at: '2026-07-27T10:00:00Z',
+        }),
+        ...tokens(PROSE),
+        event('done', { message_id: 'm1' }),
+        event('layout_start', {}),
+      ],
+      [event('ui', { program: PROGRAM, format: 'explanation' })],
+    )
+
+    const { container } = render(<AdminChat />)
+    await ask()
+
+    // Mid-turn: the answer is complete, the layout is not. The admin reads prose.
+    await waitFor(() => expect(screen.getByText('Dando formato...')).toBeInTheDocument())
+    expect(screen.getByText('Noa').tagName).toBe('STRONG')
+    // `org_data` is parsed by nobody and breaks nothing — the handler ignores it.
+    expect(container.textContent).not.toContain('generated_at')
+
+    release()
+
+    await waitFor(() =>
+      expect(container.querySelector('[data-ui-format="explanation"]')).not.toBeNull(),
+    )
+    // A real table, not four paragraphs pretending to be one.
+    expect(container.querySelectorAll('table thead th')).toHaveLength(3)
+    expect(container.querySelectorAll('table tbody tr')).toHaveLength(2)
+    expect(container.textContent).toContain('Tres de cinco empleados van con retraso.')
+
+    // The prose was the streaming phase and nothing more: blocks or prose, never both.
+    expect(container.textContent).not.toContain('se ha quedado en el 20%')
+    expect(container.textContent).not.toContain('**Noa**')
+    expect(screen.queryByText('Dando formato...')).not.toBeInTheDocument()
+  })
+
+  it('renders the fallback prose as markdown when no layout is produced', async () => {
+    stream([
+      event('grounding', { grounding: 'general' }),
+      ...tokens(PROSE),
+      event('done', { message_id: 'm1' }),
+      event('layout_start', {}),
+      event('layout_skipped', {}),
+    ])
+
+    const { container } = render(<AdminChat />)
+    await ask()
+
+    await waitFor(() => expect(container.querySelector('ul')).not.toBeNull())
+    expect(screen.getByText('Noa').tagName).toBe('STRONG')
+    expect(screen.getByText('Iker').tagName).toBe('EM')
+    expect(container.textContent).not.toContain('- **Noa**')
+    expect(container.querySelector('[data-ui-format]')).toBeNull()
+    // The honesty note survives either way — it is not the answer.
+    expect(screen.getByText(/Conocimiento general/)).toBeInTheDocument()
+    // Cleared by `layout_skipped`, not left spinning forever.
+    expect(screen.queryByText('Dando formato...')).not.toBeInTheDocument()
+  })
+
+  it('keeps the prose when the browser gate refuses the program', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const release = stream(
+      [...tokens(PROSE), event('done', { message_id: 'm1' }), event('layout_start', {})],
+      [event('ui', { program: REACTIVE_PROGRAM, format: 'explanation' })],
+    )
+
+    const { container } = render(<AdminChat />)
+    await ask()
+
+    await waitFor(() => expect(screen.getByText('Dando formato...')).toBeInTheDocument())
+    release()
+    // The notice clearing is the `ui` event having been applied to the message.
+    await waitFor(() => expect(screen.queryByText('Dando formato...')).not.toBeInTheDocument())
+
+    // Not a blank bubble: the server validated this program and our stricter gate
+    // still refused it, so the answer the admin was already reading stays put.
+    expect(container.querySelector('[data-ui-format]')).toBeNull()
+    expect(container.textContent).not.toContain('Datos del equipo')
+    expect(screen.getByText('Noa').tagName).toBe('STRONG')
+  })
+
+  it('does not run the question the admin typed through markdown', async () => {
+    stream([event('token', { content: 'Vale.' }), event('done', { message_id: 'm1' })])
+
+    const { container } = render(<AdminChat />)
+    await ask('que empleados llevan **cero** cursos')
+
+    await waitFor(() => expect(container.textContent).toContain('Vale.'))
+    expect(container.textContent).toContain('**cero**')
+  })
+})

--- a/apps/skillnet-web/src/pages/admin/Chat.tsx
+++ b/apps/skillnet-web/src/pages/admin/Chat.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import type { FormEvent } from 'react'
 import { Button } from '../../components/ui'
-import { ChatMarkdown } from '../../components/chat'
+import { ChatAnswer } from '../../components/chat'
 import { useChat } from '../../api/chat'
 import type { ChatMessage } from '../../types'
 
@@ -23,31 +23,36 @@ function Bubble({ message }: { message: ChatMessage }) {
           isUser ? 'bg-primary text-white rounded-xl rounded-br-sm' : 'bg-bg-muted text-text rounded-xl rounded-bl-sm'
         }`}
       >
-        {/*
-          Same honesty note as the employee tutor, same reason. No blocks here: the
-          admin assistant answers in two operational lines and a wall of blocks
-          would be slower to act on than the sentence it replaced.
-
-          `_should_lay_out` in `chat_service.py` never lays out an `admin` turn, so no
-          `ui` event can reach this bubble — and rendering `ChatMarkdown` rather than
-          `ChatAnswer` keeps that a decision rather than a coincidence. Which makes
-          this the surface that proves the markdown map on its own: it is the one chat
-          in the product where prose is *always* the whole answer.
-        */}
+        {/* Same honesty note as the employee tutor, same reason. */}
         {!isUser && message.grounding === 'general' && (
           <p className="text-xs text-text-muted mb-1.5" data-grounding="general">
             Conocimiento general: no sale de la documentacion subida
           </p>
         )}
+
+        {/*
+          What the admin typed is what the admin typed: no markdown pass over the
+          user's own bubble. `ChatAnswer` owns the assistant side, and it is the very
+          same component the tutor uses — blocks when a program arrives and clears the
+          browser's gate, the streamed prose otherwise, never both.
+
+          This used to be `ChatMarkdown` directly, on the grounds that the admin
+          assistant answers in two operational lines. `_should_lay_out` in
+          `chat_service.py` now lays out `admin` turns too, because the question this
+          surface exists for — "como van mis empleados" — is five people and four
+          columns, which is a table everywhere else an administrator works. The two
+          switches and the fall back to prose are unchanged; only the exclusion went.
+        */}
         {isUser ? (
           <p className="whitespace-pre-line break-words">{message.content}</p>
         ) : (
-          <>
-            <ChatMarkdown content={message.content} isStreaming={message.isStreaming} />
-            {message.isStreaming && !message.content && (
-              <p className="text-text-muted">Escribiendo...</p>
-            )}
-          </>
+          <ChatAnswer message={message} />
+        )}
+
+        {/* The second beat is now reachable here, so it has to be visible here too:
+            `done` returns the composer while the layout call is still running. */}
+        {message.isLayingOut && (
+          <p className="text-xs text-text-muted mt-2">Dando formato...</p>
         )}
       </div>
     </div>
@@ -73,13 +78,15 @@ export function AdminChat() {
   }
 
   return (
-    <div className="flex flex-col h-[calc(100vh-50px-48px)]">
+    // No inner scroll — see the note in the employee Chat. The log grows, the page
+    // scrolls, and the composer below stays put.
+    <div className="flex flex-col">
       <div className="mb-4">
         <h2 className="text-xl font-semibold text-text">Asistente</h2>
         <p className="text-sm text-text-secondary mt-0.5">Pregunta sobre cursos, empleados o la plataforma</p>
       </div>
 
-      <div className="flex-1 overflow-y-auto space-y-4 pb-4">
+      <div className="space-y-4 pb-4">
         {messages.length === 0 && (
           <div className="text-center py-12 px-4">
             <p className="text-sm font-medium text-text">¿En que puedo ayudarte?</p>
@@ -92,7 +99,10 @@ export function AdminChat() {
         <div ref={endRef} />
       </div>
 
-      <form onSubmit={handleSubmit} className="flex gap-2 pt-4 border-t border-border">
+      <form
+        onSubmit={handleSubmit}
+        className="sticky bottom-0 flex gap-2 py-4 border-t border-border bg-bg"
+      >
         <input
           type="text"
           value={input}

--- a/apps/skillnet-web/src/pages/admin/Chat.tsx
+++ b/apps/skillnet-web/src/pages/admin/Chat.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import type { FormEvent } from 'react'
 import { Button } from '../../components/ui'
+import { ChatMarkdown } from '../../components/chat'
 import { useChat } from '../../api/chat'
 import type { ChatMessage } from '../../types'
 
@@ -26,16 +27,28 @@ function Bubble({ message }: { message: ChatMessage }) {
           Same honesty note as the employee tutor, same reason. No blocks here: the
           admin assistant answers in two operational lines and a wall of blocks
           would be slower to act on than the sentence it replaced.
+
+          `_should_lay_out` in `chat_service.py` never lays out an `admin` turn, so no
+          `ui` event can reach this bubble — and rendering `ChatMarkdown` rather than
+          `ChatAnswer` keeps that a decision rather than a coincidence. Which makes
+          this the surface that proves the markdown map on its own: it is the one chat
+          in the product where prose is *always* the whole answer.
         */}
         {!isUser && message.grounding === 'general' && (
           <p className="text-xs text-text-muted mb-1.5" data-grounding="general">
             Conocimiento general: no sale de la documentacion subida
           </p>
         )}
-        <p className="whitespace-pre-line break-words">
-          {message.content}
-          {message.isStreaming && !message.content && <span className="text-text-muted">Escribiendo...</span>}
-        </p>
+        {isUser ? (
+          <p className="whitespace-pre-line break-words">{message.content}</p>
+        ) : (
+          <>
+            <ChatMarkdown content={message.content} isStreaming={message.isStreaming} />
+            {message.isStreaming && !message.content && (
+              <p className="text-text-muted">Escribiendo...</p>
+            )}
+          </>
+        )}
       </div>
     </div>
   )

--- a/apps/skillnet-web/src/pages/admin/Employees.tsx
+++ b/apps/skillnet-web/src/pages/admin/Employees.tsx
@@ -334,22 +334,34 @@ export function Employees() {
         )}
       </Card>
 
-      {/* Mobile cards */}
-      <motion.div className="mt-4 space-y-3 md:hidden" initial="hidden" animate="visible" variants={staggerContainer}>
-        {!isLoading && !error && employees.map((emp) => (
-          <motion.div key={emp.id} variants={staggerItem}>
-            <Card variant="interactive" onClick={(e) => openDetail(emp, e)}>
-              <div className="flex items-start justify-between gap-2">
-                <div className="min-w-0">
-                  <p className="font-medium text-text truncate">{emp.full_name}</p>
-                  <p className="text-sm text-text-secondary mt-0.5 truncate">{emp.email}</p>
+      {/* Mobile cards. The loading branch is a real placeholder and not `!isLoading &&`:
+          below `md` the desktop card above is `display: none`, so with nothing here the
+          whole list reserved zero height and the page grew by the full list the moment
+          the data landed. One card per skeleton, so the placeholder has the shape of
+          what replaces it. */}
+      {isLoading ? (
+        <div className="mt-4 space-y-3 md:hidden">
+          <Card><SkeletonRow /></Card>
+          <Card><SkeletonRow /></Card>
+          <Card><SkeletonRow /></Card>
+        </div>
+      ) : (
+        <motion.div className="mt-4 space-y-3 md:hidden" initial="hidden" animate="visible" variants={staggerContainer}>
+          {!error && employees.map((emp) => (
+            <motion.div key={emp.id} variants={staggerItem}>
+              <Card variant="interactive" onClick={(e) => openDetail(emp, e)}>
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="font-medium text-text truncate">{emp.full_name}</p>
+                    <p className="text-sm text-text-secondary mt-0.5 truncate">{emp.email}</p>
+                  </div>
+                  <Badge variant="primary" badgeStyle="plain">{emp.role === 'admin' ? 'Admin' : 'Empleado'}</Badge>
                 </div>
-                <Badge variant="primary" badgeStyle="plain">{emp.role === 'admin' ? 'Admin' : 'Empleado'}</Badge>
-              </div>
-            </Card>
-          </motion.div>
-        ))}
-      </motion.div>
+              </Card>
+            </motion.div>
+          ))}
+        </motion.div>
+      )}
 
       {/* Create-employee modal */}
       <Modal open={creating} onClose={() => setCreating(false)} size="lg" origin={createOrigin}>

--- a/apps/skillnet-web/src/pages/admin/Settings.tsx
+++ b/apps/skillnet-web/src/pages/admin/Settings.tsx
@@ -1,136 +1,145 @@
-import { Card, CardTitle, Badge, Button, SkeletonRow } from '../../components/ui'
-import { useSettings, useTestLlm, useUpdateFeatures } from '../../api/settings'
+import { SkeletonRow } from '../../components/ui'
+import { useSettings, useUpdateFeatures } from '../../api/settings'
 import { ApiError } from '../../api/client'
+import type { OrgSettings } from '../../types'
 
 /**
- * Two cards, and the split between them is the point.
+ * What the admin can actually change, and nothing else.
  *
- * The provider is **read-only**: it lives in the deployment's `.env`, because SkillNet
- * runs one organization per deployment and the person who owns the API key is the person
- * who deployed it. What stays here is the operational question an admin genuinely has —
- * is the AI configured, and does it answer? — which is worth answering without an SSH
- * session.
+ * The AI provider used to be shown here. It is gone: it lives in the deployment's
+ * `.env`, so an admin could read it but never act on it, and a model id on screen is
+ * noise to the person running the training. When something fails to generate the error
+ * now says why — in the moment, where it happens, which beats a page you have to
+ * remember to visit.
  *
- * The feature switches are writable, because how the product behaves is the admin's
- * call, not the deployer's.
+ * What survives from that card is one line, and only when it earns itself: a warning if
+ * no model is configured at all. That is the single case where this screen tells the
+ * admin something they could not otherwise find out — nothing works, and nothing else
+ * explains why.
  */
+
+function Toggle({
+  checked,
+  disabled,
+  onChange,
+  label,
+}: {
+  checked: boolean
+  disabled?: boolean
+  onChange: (next: boolean) => void
+  label: string
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className={`relative shrink-0 w-11 h-6 rounded-full transition-colors duration-200
+        disabled:opacity-50 disabled:cursor-not-allowed
+        focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40
+        ${checked ? 'bg-primary' : 'bg-border'}`}
+    >
+      <span
+        className={`absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow-sm
+          transition-transform duration-200 ${checked ? 'translate-x-5' : 'translate-x-0'}`}
+      />
+    </button>
+  )
+}
+
+function SettingRow({
+  title,
+  description,
+  children,
+}: {
+  title: string
+  description: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex items-start justify-between gap-6 py-5 border-b border-border">
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-text">{title}</p>
+        <p className="text-sm text-text-secondary mt-1">{description}</p>
+      </div>
+      {children}
+    </div>
+  )
+}
+
 export function Settings() {
   const { data: settings, isLoading, error } = useSettings()
-  const test = useTestLlm()
   const features = useUpdateFeatures()
 
   return (
-    <div className="max-w-2xl">
-      <div className="mb-4">
+    <div>
+      <div className="mb-2">
         <h2 className="text-xl font-semibold text-text">Ajustes</h2>
-        <p className="text-sm text-text-secondary mt-0.5">Estado del proveedor de IA y comportamiento del tutor</p>
+        <p className="text-sm text-text-secondary mt-0.5">
+          Como se comporta SkillNet para tu organizacion.
+        </p>
       </div>
 
       {isLoading ? (
-        <Card><SkeletonRow /></Card>
+        <div className="py-5">
+          <SkeletonRow />
+        </div>
       ) : error ? (
-        <Card><p className="text-sm text-danger">No se pudieron cargar los ajustes.</p></Card>
-      ) : (
-        <Card>
-          <div className="flex items-center justify-between mb-4">
-            <CardTitle>Proveedor de IA (LLM)</CardTitle>
-            <Badge variant={settings?.llm_configured ? 'accent' : 'warning'} badgeStyle="plain">
-              {settings?.llm_configured ? 'Configurado' : 'Sin configurar'}
-            </Badge>
-          </div>
-
-          <dl className="space-y-2 text-sm">
-            <div className="flex gap-3">
-              <dt className="text-text-muted w-32 shrink-0">Modelo</dt>
-              <dd className="text-text font-mono text-xs break-all min-w-0">
-                {settings?.llm_model ?? 'sin configurar'}
-              </dd>
-            </div>
-            <div className="flex gap-3">
-              <dt className="text-text-muted w-32 shrink-0">Embeddings</dt>
-              <dd className="text-text font-mono text-xs break-all min-w-0">
-                {settings?.embedding_model ?? 'sin configurar'}
-              </dd>
-            </div>
-            <div className="flex gap-3">
-              <dt className="text-text-muted w-32 shrink-0">Endpoint</dt>
-              <dd className="text-text font-mono text-xs break-all min-w-0">
-                {settings?.llm_base_url ?? 'el del proveedor'}
-              </dd>
-            </div>
-          </dl>
-
-          {test.data && (
-            <p className={`text-sm mt-4 ${test.data.ok ? 'text-accent' : 'text-danger'}`}>
-              {test.data.ok
-                ? `Conexion correcta (${test.data.model ?? ''}).`
-                : `Fallo la conexion: ${test.data.detail ?? 'error'}`}
-            </p>
-          )}
-
-          <div className="mt-4">
-            <Button
-              size="sm"
-              variant="secondary"
-              onClick={() => test.mutate()}
-              disabled={test.isPending}
-            >
-              {test.isPending ? 'Probando...' : 'Probar conexion'}
-            </Button>
-          </div>
-
-          <p className="text-xs text-text-muted mt-4">
-            El proveedor se configura en el <span className="font-mono">.env</span> del
-            despliegue (<span className="font-mono">LLM_MODEL</span>,{' '}
-            <span className="font-mono">LLM_API_KEY</span>,{' '}
-            <span className="font-mono">LLM_BASE_URL</span>), no desde aqui: la clave es de
-            quien despliega y paga el proveedor. Vale cualquiera compatible con litellm.
-            Numeros medidos por modelo en{' '}
-            <span className="font-mono">docs/design/tuning.md</span>.
-          </p>
-        </Card>
-      )}
-
-      {!isLoading && !error && settings && (
-        <Card className="mt-4">
-          <CardTitle className="mb-1">Respuestas del tutor</CardTitle>
-          <p className="text-sm text-text-secondary mb-4">
-            Como se presentan las respuestas del chat a los empleados.
-          </p>
-
-          <label className="flex items-start gap-3 cursor-pointer">
-            <input
-              type="checkbox"
-              className="mt-1 accent-primary shrink-0"
-              checked={settings.chat_generative_ui}
-              disabled={features.isPending}
-              onChange={(e) => features.mutate({ chat_generative_ui: e.target.checked })}
-            />
-            <span className="min-w-0">
-              <span className="block text-sm font-medium text-text">
-                Maquetar las respuestas con los bloques del curso
-              </span>
-              <span className="block text-sm text-text-secondary mt-0.5">
-                El tutor entrega la respuesta como pasos, tabla o aviso cuando esa es la
-                forma que mejor le va, en vez de como texto corrido. Cuesta una llamada
-                mas al modelo por respuesta.
-              </span>
-              <span className="block text-xs text-text-muted mt-1">
-                Apagado, el tutor responde en texto. Encendido, si el modelo devuelve algo
-                que no vale, la respuesta cae a texto sola: nunca se queda en blanco.
-              </span>
-            </span>
-          </label>
-
-          {features.isError && (
-            <p className="text-sm text-danger mt-3">
-              {features.error instanceof ApiError
-                ? features.error.body.detail
-                : 'No se pudo guardar el ajuste'}
-            </p>
-          )}
-        </Card>
-      )}
+        <p className="text-sm text-danger py-5">No se pudieron cargar los ajustes.</p>
+      ) : settings ? (
+        <SettingsBody settings={settings} features={features} />
+      ) : null}
     </div>
+  )
+}
+
+function SettingsBody({
+  settings,
+  features,
+}: {
+  settings: OrgSettings
+  features: ReturnType<typeof useUpdateFeatures>
+}) {
+  return (
+    <>
+      {!settings.llm_configured && (
+        <div className="mt-4 rounded-lg border border-warning/40 bg-warning/5 p-3">
+          <p className="text-sm text-text">
+            No hay ningun modelo de IA configurado, asi que no se puede generar contenido
+            ni responder en el chat.
+          </p>
+          <p className="text-xs text-text-muted mt-1">
+            Se configura en el <span className="font-mono">.env</span> del despliegue:{' '}
+            <span className="font-mono">LLM_MODEL</span> y{' '}
+            <span className="font-mono">LLM_API_KEY</span>.
+          </p>
+        </div>
+      )}
+
+      <div className="mt-2 border-t border-border">
+        <SettingRow
+          title="Maquetar las respuestas del tutor"
+          description="El tutor contesta con pasos, tablas o avisos cuando encajan mejor que un parrafo. Si el modelo no acierta, la respuesta sale en texto."
+        >
+          <Toggle
+            checked={settings.chat_generative_ui}
+            disabled={features.isPending}
+            onChange={(next) => features.mutate({ chat_generative_ui: next })}
+            label="Maquetar las respuestas del tutor"
+          />
+        </SettingRow>
+      </div>
+
+      {features.isError && (
+        <p className="text-sm text-danger mt-3">
+          {features.error instanceof ApiError
+            ? features.error.body.detail
+            : 'No se pudo guardar el ajuste'}
+        </p>
+      )}
+    </>
   )
 }

--- a/apps/skillnet-web/src/pages/employee/Chat.test.tsx
+++ b/apps/skillnet-web/src/pages/employee/Chat.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Chat } from './Chat'
+import { AdminChat } from '../admin/Chat'
+
+/**
+ * The tutor chat as a *screen*, driven by the bytes the server really sends.
+ *
+ * `api/chat.test.ts` already proves the stream parser. It proved it while the screen
+ * was wrong, which is the whole reason this file exists: every assertion below reads
+ * the DOM after a full SSE turn, so "the `ui` event landed on the message object" can
+ * never again be mistaken for "the learner saw blocks".
+ *
+ * The two turns asserted are the two the product actually has:
+ *
+ * - **prose then blocks** — the long answer that earns a layout call. The prose is the
+ *   streaming phase and must be gone by the end.
+ * - **prose only** — `layout_skipped`, an answer under `MIN_LAYOUT_CHARS`, either
+ *   feature switch off, or the admin assistant, which never lays out at all. Measured
+ *   against the live stack, this is the majority of turns, so it is the case that has
+ *   to look deliberate rather than the one that is allowed to look raw.
+ */
+
+const mockFetch = vi.fn()
+
+const PROGRAM = [
+  'root = Stack([intro, pasos], "md")',
+  'intro = TextContent("Consulta siempre la ficha del producto.", "lead")',
+  'pasos = StepSequence("Atender una consulta de alergenos", ["Escucha la pregunta", "Consulta la ficha"])',
+].join('\n')
+
+/** Real tutor output: markdown, because that is what the prompt produces. */
+const PROSE = [
+  'Claro, te explico como atender una consulta de alergenos.',
+  '',
+  '1. **Escucha la pregunta** del cliente.',
+  '2. *Nunca* improvises: consulta la ficha.',
+].join('\n')
+
+function event(type: string, data: unknown) {
+  return `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`
+}
+
+/** One frame per token, exactly as `format_sse` writes them. */
+function stream(...frames: string[]) {
+  const encoder = new TextEncoder()
+  let index = 0
+  mockFetch.mockImplementation(() =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      body: {
+        getReader: () => ({
+          read: () =>
+            index < frames.length
+              ? Promise.resolve({ done: false, value: encoder.encode(frames[index++]) })
+              : Promise.resolve({ done: true, value: undefined }),
+        }),
+      },
+    }),
+  )
+}
+
+function tokens(text: string) {
+  return (text.match(/\S+\s*/g) ?? []).map((chunk) => event('token', { content: chunk }))
+}
+
+async function ask(placeholder: RegExp, question = 'como atiendo una consulta de alergenos') {
+  const user = userEvent.setup()
+  const input = screen.getByPlaceholderText(placeholder)
+  await user.type(input, question)
+  await user.keyboard('{Enter}')
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  vi.stubGlobal('fetch', mockFetch)
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('employee Chat', () => {
+  it('replaces the prose with the kit program when the layout lands', async () => {
+    stream(
+      event('grounding', { grounding: 'document' }),
+      ...tokens(PROSE),
+      event('citations', { citations: [{ document: 'Manual de alergenos' }] }),
+      event('done', { message_id: 'm1' }),
+      event('layout_start', {}),
+      event('ui', { program: PROGRAM, format: 'explanation' }),
+    )
+
+    const { container } = render(<Chat />)
+    await ask(/pregunta/i)
+
+    await waitFor(() =>
+      expect(container.querySelector('[data-ui-format="explanation"]')).not.toBeNull(),
+    )
+    expect(container.textContent).toContain('Atender una consulta de alergenos')
+    expect(container.querySelectorAll('ol > li')).toHaveLength(2)
+
+    // The prose was the streaming phase and nothing more.
+    expect(container.textContent).not.toContain('Nunca improvises')
+    expect(container.textContent).not.toContain('**Escucha')
+    // The provenance line and the citations survive the swap — they are not the answer.
+    expect(screen.getByText(/De la documentacion de tus cursos/)).toBeInTheDocument()
+    expect(screen.getByText(/Manual de alergenos/)).toBeInTheDocument()
+  })
+
+  it('renders the fallback prose as markdown when no layout is produced', async () => {
+    stream(
+      event('grounding', { grounding: 'document' }),
+      ...tokens(PROSE),
+      event('done', { message_id: 'm1' }),
+      event('layout_start', {}),
+      event('layout_skipped', {}),
+    )
+
+    const { container } = render(<Chat />)
+    await ask(/pregunta/i)
+
+    await waitFor(() => expect(container.querySelector('ol')).not.toBeNull())
+    expect(screen.getByText('Escucha la pregunta').tagName).toBe('STRONG')
+    expect(screen.getByText('Nunca').tagName).toBe('EM')
+    expect(container.textContent).not.toContain('**Escucha')
+    expect(container.querySelector('[data-ui-format]')).toBeNull()
+    // "Dando formato..." is cleared by `layout_skipped`, not left spinning forever.
+    expect(screen.queryByText('Dando formato...')).not.toBeInTheDocument()
+  })
+
+  it('does not run the question the learner typed through markdown', async () => {
+    stream(event('token', { content: 'Vale.' }), event('done', { message_id: 'm1' }))
+
+    const { container } = render(<Chat />)
+    await ask(/pregunta/i, 'que significa **sin gluten** exactamente')
+
+    await waitFor(() => expect(container.textContent).toContain('Vale.'))
+    expect(container.textContent).toContain('**sin gluten**')
+  })
+})
+
+describe('admin Chat', () => {
+  it('renders the assistant answer as markdown — prose is always the whole answer here', async () => {
+    stream(
+      event('grounding', { grounding: 'general' }),
+      ...tokens('Sigue estos pasos:\n\n- **Revisa** el parte\n- Habla con sala'),
+      event('done', { message_id: 'm1' }),
+    )
+
+    const { container } = render(<AdminChat />)
+    await ask(/consulta/i, 'como veo el estado de los empleados')
+
+    await waitFor(() => expect(container.querySelector('ul')).not.toBeNull())
+    expect(screen.getByText('Revisa').tagName).toBe('STRONG')
+    expect(container.textContent).not.toContain('- **Revisa**')
+    expect(screen.getByText(/Conocimiento general/)).toBeInTheDocument()
+  })
+})

--- a/apps/skillnet-web/src/pages/employee/Chat.tsx
+++ b/apps/skillnet-web/src/pages/employee/Chat.tsx
@@ -103,13 +103,17 @@ export function Chat() {
   }
 
   return (
-    <div className="flex flex-col h-[calc(100vh-50px-48px)]">
+    // No fixed height and no inner scroll: the log grows and the *page* scrolls.
+    // It used to be `h-[calc(100vh-50px-48px)]` with an `overflow-y-auto` log, which
+    // was a scroll box inside a page that now scrolls on its own — two scrollbars for
+    // one conversation. `endRef.scrollIntoView` keeps working; it just moves the page.
+    <div className="flex flex-col">
       <div className="mb-4">
         <h2 className="text-xl font-semibold text-text">Chat</h2>
         <p className="text-sm text-text-secondary mt-0.5">Pregunta sobre tus cursos y procedimientos</p>
       </div>
 
-      <div className="flex-1 overflow-y-auto space-y-4 pb-4">
+      <div className="space-y-4 pb-4">
         {messages.length === 0 && (
           <div className="text-center py-12 px-4">
             <p className="text-sm font-medium text-text">Hazme una pregunta</p>
@@ -124,7 +128,12 @@ export function Chat() {
         <div ref={endRef} />
       </div>
 
-      <form onSubmit={handleSubmit} className="flex gap-2 pt-4 border-t border-border">
+      {/* Sticky, so removing the inner scroll does not bury the composer at the bottom
+          of a long conversation. It stays on screen; the messages scroll behind it. */}
+      <form
+        onSubmit={handleSubmit}
+        className="sticky bottom-0 flex gap-2 py-4 border-t border-border bg-bg"
+      >
         <input
           type="text"
           value={input}

--- a/apps/skillnet-web/src/pages/employee/Chat.tsx
+++ b/apps/skillnet-web/src/pages/employee/Chat.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import type { FormEvent } from 'react'
 import { Button } from '../../components/ui'
-import { UiSpecRenderer } from '../../components/courses/UiSpecRenderer'
+import { ChatAnswer } from '../../components/chat'
 import { useChat } from '../../api/chat'
 import type { ChatGrounding, ChatMessage } from '../../types'
 
@@ -52,25 +52,14 @@ function ChatBubble({ message }: { message: ChatMessage }) {
         {!isUser && <GroundingNote grounding={message.grounding} />}
 
         {/*
-          The blocks replace the prose only once there is a program, and the prose
-          is what comes back if there never is one. `UiSpecRenderer` returns null
-          for a blocked or empty program, so rendering the two alternatives (rather
-          than the blocks stacked on top of the text) is what would risk an empty
-          bubble — hence the program is only chosen when the server sent one, and
-          the server only sends one that already parsed into a valid `UISpec`.
+          What the learner typed is what the learner typed: no markdown pass over the
+          user's own bubble, which would turn an asterisked note into emphasis they
+          did not ask for. `ChatAnswer` owns the two-beat assistant answer.
         */}
-        {message.program ? (
-          <UiSpecRenderer program={message.program} nodeId="" format="explanation" />
+        {isUser ? (
+          <p className="whitespace-pre-line break-words">{message.content}</p>
         ) : (
-          <p className="whitespace-pre-line break-words">
-            {message.content}
-            {message.isStreaming && !message.content && (
-              <span className="text-text-muted">Escribiendo...</span>
-            )}
-            {message.isStreaming && message.content && (
-              <span className="inline-block w-1.5 h-4 ml-0.5 align-middle bg-current opacity-60 animate-pulse" />
-            )}
-          </p>
+          <ChatAnswer message={message} />
         )}
 
         {message.isLayingOut && (


### PR DESCRIPTION
Siete commits, todos salidos de probar la aplicación a mano y encontrar que lo que se veía en pantalla no era lo que los tests decían.

## Lo que más importa: los renders dejaron de fallar

El nodo de alérgenos salía como catorce alérgenos en un párrafo con comas, en 25,7 segundos, usando tres de los nueve bloques disponibles. Medido sobre los mismos 10 encargos contra Groq real:

| | antes (30) | después (20) |
|---|---|---|
| acierto a la primera | 46,7 % | **95,0 %** |
| acaban en fallback | 16,7 % | **0,0 %** |
| llamadas a `genera_ui` necesarias | 46 | 21 |
| uso de `Table` | 4,1 % | 8,5 % |

Y ese nodo, ahora, a la primera y en **1.156 ms** en vez de 25.754:

```
lista = Table(["Alergeno"], [["Gluten"], ["Crustaceos"], ["Huevos"], …])
```

Tres causas, y ninguna era «el modelo es malo»:

- **Los 25 segundos no eran el modelo.** `llm_usage_log` guarda ese render como dos llamadas, 1.039 ms y 24.715 ms, de los cuales unos 23.700 durmiendo. Las dos juntas son 6.491 tokens de entrada contra un límite de 6.000 por minuto, así que la segunda recibe un 429 y la espera cae dentro del tramo que `duration_ms` mide. En toda la línea base: 63 esperas, 1.191 segundos dormidos en 30 renders. El p50 seguía a `tokens_in` y nunca a `tokens_out` — la latencia aquí es presupuesto de tokens, no velocidad de modelo.
- **Tres bloques de nueve no era una restricción de paleta.** El único ejemplo trabajado del prompt tenía forma de prosa, y una regla ofrecía «un solo TextContent cuyo texto lleve la enumeracion» como alternativa de igual rango que Table o StepSequence — la más barata, así que ganaba. El mismo hueco tiene otra cara: en otro encargo el modelo emitió diecinueve componentes, uno por alérgeno, y lo rechazó la regla 4. Párrafo y diecinueve bloques son el mismo defecto: nada conectaba «catorce alérgenos» con una forma.
- **El grupo de fallos más grande estaba en cómo redactábamos el prompt.** Ocho de unos treinta rechazos eran `prop 'tone' must be one of: info, warn, success (got 'critical')`, porque el prompt imprimía `- Criticidad: critical` cuatro líneas encima de un componente cuyo primer argumento es un enum de tono. Prohibirlo por escrito perdió; borrar la palabra ganó.

De paso, un agujero real en la puerta: `STRING_MATRIX` nunca comprobaba que cada fila tuviera tantas celdas como cabeceras, así que servía tan tranquila una tabla de una fila con catorce celdas.

## El chat deja de escribir marcado

La llamada de maquetado pedía al modelo que escribiera un programa OpenUI Lang. Ahora devuelve **un objeto JSON** — una forma de un enum de cinco valores más sus campos — y el servidor escribe el programa.

La evidencia es nuestra, no prestada. Clasificados todos los errores del validador de los volcados: **diez de diez son errores de escribir marcado** — una tilde dentro de un identificador, `{` para un objeto, argumentos con nombre, el doble del tope de líneas. Ni uno es «eligió el bloque equivocado» ni «se equivocó en el contenido». El juicio del modelo sobre la forma nunca fue lo que falló; su mecanografía sí.

Efecto lateral que decide si esto es viable: el prompt de maquetado encogió un **72 %**, de 7.988 a 2.176 caracteres. Con una clave de 6.000 tokens por minuto, eso es la diferencia entre que el asistente del admin pueda maquetar y que no.

Una llamada y no las dos de Curio: parte clasificar de rellenar porque corre modelos de 1-4B en local, y aquí duplicar latencia y exposición al límite de cuota para reducir un enum de cinco ramas es el intercambio equivocado.

**Verdicto en contra de rehacer el motor de nodos igual**, y sobre evidencia: los rechazos por argumentos con nombre de los volcados antiguos venían del fixture de pruebas, no del modelo. 95 % a la primera con cero fallbacks dice que la mitad barata de la idea de Curio bastaba.

## Generative UI en los dos chats

El asistente del admin estaba excluido. Era una decisión mía y era mala: explorar generative UI es el objetivo del proyecto, y el caso más fuerte del producto era justo el excluido — una pregunta sobre cinco empleados son datos tabulares aplanados en cinco párrafos.

El motivo real de que no funcionara era más tonto de lo que parecía: `routes/chat.py` nunca pasaba `generative_ui` al servicio, así que estaba en `False` por defecto. Invisible mientras existía la exclusión, y el fallo entero en cuanto se levantó.

## El asistente del admin responde con datos reales

Preguntado «cómo van mis empleados», contestaba con cuatro viñetas de consejos de gestión — *revisa el parte de incidencias, habla con el encargado* — mientras la respuesta estaba en la base de datos.

`org_snapshot.py` monta los hechos en ocho consultas agregadas. Elegido sobre llamada a herramientas con números: 3,1 kB para cinco empleados, ~45 tokens más por empleado, así que cuarenta empleados siguen costando menos que una ida y vuelta de herramienta en latencia. Pasados cuarenta cambia a totales más las personas que necesitan atención, y **lo dice en el bloque** en vez de truncar en silencio.

La raya de privacidad se sostiene por tres mecanismos independientes, no por cuidado: ninguna consulta toca las columnas privadas, `EmployeeFact` es un dataclass congelado de siete campos sin sitio donde meter una, y un test parsea el AST del módulo y falla si aparece un acceso a `preset`, `experience_level`, `format_vector`, `tutor_notes`, `goal`, `learning_profile` o `accessibility`.

Tres defectos que salieron al usarlo:

- **«quien eres»** devolvía *«No consta la informacion de identidad del administrador»* — buscaba al admin en los datos en vez de decir quién es él. Ahora se responde como un saludo: cero tokens, ninguna consulta.
- **«usa openui para esta respuesta»** era un callejón sin salida. El primer arreglo lo empeoró: contestó pegando el bloque entero de datos y los dos documentos, cuatro kilobytes con los expedientes de cinco personas. Cambiar una negativa por un volcado de contexto es la misma no-respuesta, más grande.
- **La acción de cierre se disparaba en todas las respuestas.** Una pregunta sobre alérgenos terminaba en «Escribe a Aitana, que no ha abierto ninguno de sus tres cursos».

`invented_figures` rechaza cualquier programa con una tirada de dígitos que la prosa no tuviera. Estos bloques nombran personas reales, así que «no inventes cifras» tenía que ser mecánico y no una regla de prompt; pilló tres fixtures propios donde la tabla no cuadraba con su respuesta.

## El markdown del chat nunca se renderizaba como markdown

Reportado como «el chat genera markdown y ni siquiera lo renderiza bien». La mitad de OpenUI ya funcionaba —comprobado de tres formas antes de tocar nada— y la otra mitad era peor de lo descrito: la prosa se pintaba con un `<p className="whitespace-pre-line">`, sin `react-markdown`, que es dependencia de esta app y el chat no usaba.

Y es el camino **mayoritario**: de las diez últimas respuestas del asistente, dos con programa y ocho sin. El asistente del admin no maquetaba nunca, las respuestas cortas tampoco, y el validador rechaza algunas.

`ChatAnswer` valida el programa **antes** de comprometerse a los bloques, lo que cierra un agujero real: `UiSpecRenderer` responde «¿se puede pintar esto?» con `null`, y un `null` en una burbuja de chat es una burbuja vacía con la prosa ya descartada.

## Y tres cosas de layout, todas encontradas usando la app

- **El `<main>` era una caja con scroll propio** (`overflow-y-auto`) en vez de crecer, así que una lista larga scrolleaba dentro del panel mientras la ventana se quedaba quieta. Nada lo necesitaba: la barra lateral y la cabecera son `fixed`.
- **Y al quitarlo dejé una trampa**: `overflow-x: hidden` obliga al eje vertical de `visible` a `auto`, así que iba a recrear el contenedor de scroll que acababa de quitar. Ahora es `clip`.
- **La reserva de la barra de scroll no siguió al scroll.** `scrollbar-gutter: stable` estaba en `.overflow-y-auto` — que era `main` mientras `main` scrolleaba. Al pasar el scroll a la página, `html` no encajaba con nada y la reserva dejó de existir justo cuando empezaba a importar: 10 px de salto horizontal al aparecer la barra, que recolocaban las tarjetas y añadían 44 px de altura. Un detalle de método que invalidó toda una primera tanda de medidas: **Chromium sin ventana usa barras superpuestas**, así que `innerWidth - clientHeight` da 0 sin ventana y 15 con ella.

En Ajustes desaparece la tarjeta del proveedor de IA: se volvió de solo lectura cuando el proveedor pasó al `.env`, y solo lectura era el problema — el admin podía mirar `groq/llama-3.1-8b-instant` y no hacer nada, porque quien puede cambiarlo ya tiene el fichero abierto. Sobrevive una línea, y solo cuando se la gana: un aviso si no hay ningún modelo configurado.

## Pruebas

| | |
|---|---|
| Backend, unitarias | 2.671 |
| Backend, integración | 16 |
| Frontend | 431 |

`tsc -b` limpio, lint limpio, ruff en las 5 violaciones heredadas de `main`. Sigue rojo `tests/test_grading.py::test_grade_open_answer_fallback`, roto desde `c68d045` — el desfasado es el test, no el código.

## Lo que queda dicho y no hecho

- **El componente `List`.** `Table` con una columna es un apaño para un hueco real del catálogo: no hay forma de expresar «una enumeración de N cosas», que es la forma más común de este dominio. Propuesta medida: añadir `List`, quitar `CodeBlock` (cero usos en 171 bloques, y ni uno de los diez encargos ni de los cuatro documentos contiene código), total de emitibles sin subir. No se ha aplicado porque el navegador resuelve el componente por nombre: un `List` servido sin su bloque de React no pinta nada, y eso es peor que el fallo de partida. Va en un solo parche coordinado.
- **`Chart` no se elige nunca** (cero usos), pero el bloque no sobra: hay un documento sembrado con cinco temperaturas representables. Lo que falla es que `decide_formato` nunca selecciona ese formato. Quitarlo tocaría el enum, una migración, el router y el sembrado — cambio aparte.
- **`docs/design/chat-agents.md`** sigue describiendo el chat que escribe el programa.
