### PR TITLE
feat: primer servidor MCP para SkillNet (cliente fino de /ext/v1)

### DIFF
--- a/apps/skillnet-api/alembic/versions/0020_api_key_expires_at.py
+++ b/apps/skillnet-api/alembic/versions/0020_api_key_expires_at.py
@@ -1,0 +1,30 @@
+"""Add ``api_keys.expires_at``: optional expiry for external API keys.
+
+The data model documented in ``docs/design/mcp-external-api.md`` (8.1.1) always
+included ``expires_at``, but the column never made it into migration 0003. Nullable
+and additive: existing keys read as "never expires" (``null``), matching the
+documented default. See ``src/routes/ext/auth.py`` for the enforcement.
+
+Revision ID: 0020
+Revises: 0019
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0020"
+down_revision: str | None = "0019"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "api_keys",
+        sa.Column("expires_at", sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("api_keys", "expires_at")

--- a/apps/skillnet-api/src/models/api_key.py
+++ b/apps/skillnet-api/src/models/api_key.py
@@ -24,4 +24,5 @@ class ApiKey(UUIDMixin, Base):
     scopes: Mapped[list[str]] = mapped_column(ARRAY(String), nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     last_used_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    expires_at: Mapped[datetime | None] = mapped_column(nullable=True)
     created_at: Mapped[datetime] = mapped_column(server_default=text("now()"))

--- a/apps/skillnet-api/src/routes/ext/auth.py
+++ b/apps/skillnet-api/src/routes/ext/auth.py
@@ -24,6 +24,8 @@ async def _get_api_key(
     api_key = await repo.get_by_hash(key_hash)
     if api_key is None or not api_key.is_active:
         raise ForbiddenError("Invalid or inactive API key")
+    if api_key.expires_at is not None and api_key.expires_at <= datetime.utcnow():
+        raise ForbiddenError("Invalid or inactive API key")
     # Update last_used_at. Naive on purpose, and the one place in the codebase that is:
     # `api_keys.last_used_at` is a TIMESTAMP WITHOUT TIME ZONE, and migration 0006 names it
     # explicitly as the column left naive because converting it would be churn, not a fix.
@@ -34,3 +36,26 @@ async def _get_api_key(
 
 
 ExtApiKey = Annotated[ApiKey, Depends(_get_api_key)]
+
+
+def require_scope(scope: str):
+    """Build a dependency that additionally requires ``scope`` on the API key.
+
+    Kept separate from ``_get_api_key`` so every route still gets the shared
+    validity checks (hash lookup, ``is_active``, ``expires_at``) and only adds the
+    scope check it actually needs — see the scopes table in
+    ``docs/design/mcp-external-api.md`` (8.1.1) for what each scope is meant to gate.
+    """
+
+    async def _dep(api_key: ExtApiKey) -> ApiKey:
+        if scope not in api_key.scopes:
+            raise ForbiddenError(f"API key is missing required scope: {scope}")
+        return api_key
+
+    return _dep
+
+
+RequireSkillsRead = Annotated[ApiKey, Depends(require_scope("skills:read"))]
+RequireSkillsWrite = Annotated[ApiKey, Depends(require_scope("skills:write"))]
+RequireUsersRead = Annotated[ApiKey, Depends(require_scope("users:read"))]
+RequireCoursesWrite = Annotated[ApiKey, Depends(require_scope("courses:write"))]

--- a/apps/skillnet-api/src/routes/ext/courses.py
+++ b/apps/skillnet-api/src/routes/ext/courses.py
@@ -14,7 +14,7 @@ import uuid
 from fastapi import APIRouter
 from pydantic import BaseModel, Field
 
-from src.routes.ext.auth import ExtApiKey
+from src.routes.ext.auth import RequireCoursesWrite
 from src.services.course_orchestration import create_course_end_to_end
 
 router = APIRouter(prefix="/courses", tags=["Courses (external)"])
@@ -41,7 +41,7 @@ class FullCourseRequest(BaseModel):
 
 
 @router.post("/full", status_code=201)
-async def create_full_course(api_key: ExtApiKey, body: FullCourseRequest) -> dict:
+async def create_full_course(api_key: RequireCoursesWrite, body: FullCourseRequest) -> dict:
     """Create a dynamic course end to end and return a structured result.
 
     The API key carries the organization and the admin the key was created for; the

--- a/apps/skillnet-api/src/routes/ext/skills.py
+++ b/apps/skillnet-api/src/routes/ext/skills.py
@@ -7,7 +7,11 @@ from fastapi import APIRouter, Query
 
 from src.deps.db import DBSession
 from src.repositories.skill_repo import SkillRepository
-from src.routes.ext.auth import ExtApiKey
+from src.routes.ext.auth import (
+    RequireSkillsRead,
+    RequireSkillsWrite,
+    RequireUsersRead,
+)
 from src.schemas.skill import (
     GapReport,
     GapReportEntry,
@@ -32,7 +36,7 @@ def _service(db: DBSession) -> SkillService:
 
 @router.get("", response_model=list[SkillCategoryRead])
 async def list_skills(
-    api_key: ExtApiKey,
+    api_key: RequireSkillsRead,
     db: DBSession,
 ) -> list[SkillCategoryRead]:
     service = _service(db)
@@ -42,7 +46,7 @@ async def list_skills(
 
 @router.get("/who-knows", response_model=WhoKnowsResponse)
 async def who_knows(
-    api_key: ExtApiKey,
+    api_key: RequireSkillsRead,
     db: DBSession,
     skill: Annotated[str, Query(description="Skill name to search for")],
     min_level: Annotated[str | None, Query(description="Minimum level: low, medium, high")] = None,
@@ -57,7 +61,7 @@ async def who_knows(
 
 @router.get("/gaps", response_model=GapReport)
 async def get_gaps(
-    api_key: ExtApiKey,
+    api_key: RequireSkillsRead,
     db: DBSession,
 ) -> GapReport:
     service = _service(db)
@@ -67,7 +71,7 @@ async def get_gaps(
 
 @router.post("/verify", response_model=VerifySkillResponse, status_code=200)
 async def verify_skill(
-    api_key: ExtApiKey,
+    api_key: RequireSkillsWrite,
     db: DBSession,
     body: VerifySkillRequest,
 ) -> VerifySkillResponse:
@@ -85,7 +89,7 @@ async def verify_skill(
 
 @user_router.get("/{user_id}/skills", response_model=list[UserSkillRead])
 async def get_user_skills(
-    api_key: ExtApiKey,
+    api_key: RequireUsersRead,
     db: DBSession,
     user_id: uuid.UUID,
 ) -> list[UserSkillRead]:

--- a/apps/skillnet-api/tests/test_ext_auth.py
+++ b/apps/skillnet-api/tests/test_ext_auth.py
@@ -1,0 +1,154 @@
+"""Auth hardening for /ext/v1 API keys: scopes and expires_at enforcement.
+
+Before this, `_get_api_key` only checked `is_active` — the `scopes` column was stored
+(and documented in docs/design/mcp-external-api.md, 8.1.1) but never read, and
+`expires_at` didn't exist as a column at all. These tests pin the two properties that
+matter: an expired or under-scoped key is rejected, and a key that satisfies both keeps
+working exactly like before (the A2A internal key in particular, which carries
+`skills:read`, `skills:write`, `users:read`, `courses:write` and no expiry).
+
+Uses a fake repository instead of a real Postgres connection, in line with the rest of
+the unit suite (`-m "not integration"`).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+
+from src.core.exceptions import ForbiddenError
+from src.models.api_key import ApiKey
+from src.routes.ext import auth as ext_auth
+
+
+class _FakeDB:
+    """Stands in for the AsyncSession: only `flush()` is exercised by `_get_api_key`."""
+
+    async def flush(self) -> None:
+        return None
+
+
+def _make_key(
+    *,
+    scopes: list[str],
+    is_active: bool = True,
+    expires_at: datetime | None = None,
+) -> ApiKey:
+    return ApiKey(
+        id=uuid.uuid4(),
+        org_id=uuid.uuid4(),
+        created_by=uuid.uuid4(),
+        name="test key",
+        key_hash="irrelevant",
+        scopes=scopes,
+        is_active=is_active,
+        expires_at=expires_at,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _patch_repo(monkeypatch: pytest.MonkeyPatch):
+    """Point `ApiKeyRepository.get_by_hash` at a key set by each test via `_current_key`."""
+
+    state: dict[str, ApiKey | None] = {"key": None}
+
+    async def _get_by_hash(self, key_hash: str) -> ApiKey | None:  # noqa: ARG001
+        return state["key"]
+
+    monkeypatch.setattr(ext_auth.ApiKeyRepository, "get_by_hash", _get_by_hash)
+    yield state
+
+
+async def _resolve(state, key: ApiKey | None, token: str = "sn_whatever") -> ApiKey:
+    state["key"] = key
+    return await ext_auth._get_api_key(db=_FakeDB(), authorization=f"Bearer {token}")
+
+
+# --------------------------------------------------------------------------------------
+# expires_at
+# --------------------------------------------------------------------------------------
+async def test_expired_key_is_rejected(_patch_repo):
+    key = _make_key(scopes=["skills:read"], expires_at=datetime.utcnow() - timedelta(days=1))
+    with pytest.raises(ForbiddenError):
+        await _resolve(_patch_repo, key)
+
+
+async def test_key_expiring_now_is_rejected(_patch_repo):
+    """`<=` is deliberate: a key can't be valid for the exact expiry instant."""
+    key = _make_key(scopes=["skills:read"], expires_at=datetime.utcnow())
+    with pytest.raises(ForbiddenError):
+        await _resolve(_patch_repo, key)
+
+
+async def test_key_with_future_expiry_is_accepted(_patch_repo):
+    key = _make_key(scopes=["skills:read"], expires_at=datetime.utcnow() + timedelta(days=30))
+    resolved = await _resolve(_patch_repo, key)
+    assert resolved is key
+
+
+async def test_key_with_no_expiry_is_accepted(_patch_repo):
+    key = _make_key(scopes=["skills:read"], expires_at=None)
+    resolved = await _resolve(_patch_repo, key)
+    assert resolved is key
+
+
+async def test_inactive_key_is_still_rejected(_patch_repo):
+    """Pre-existing behaviour, kept: `is_active=False` fails independently of expiry."""
+    key = _make_key(scopes=["skills:read"], is_active=False)
+    with pytest.raises(ForbiddenError):
+        await _resolve(_patch_repo, key)
+
+
+async def test_unknown_key_is_rejected(_patch_repo):
+    with pytest.raises(ForbiddenError):
+        await _resolve(_patch_repo, None)
+
+
+# --------------------------------------------------------------------------------------
+# scopes
+# --------------------------------------------------------------------------------------
+async def test_require_scope_rejects_key_missing_the_scope():
+    key = _make_key(scopes=["skills:read"])
+    dep = ext_auth.require_scope("skills:write")
+    with pytest.raises(ForbiddenError):
+        await dep(key)
+
+
+async def test_require_scope_accepts_key_with_the_scope():
+    key = _make_key(scopes=["skills:read", "skills:write"])
+    dep = ext_auth.require_scope("skills:write")
+    resolved = await dep(key)
+    assert resolved is key
+
+
+async def test_require_scope_error_never_echoes_the_key_material():
+    key = _make_key(scopes=[])
+    dep = ext_auth.require_scope("courses:write")
+    with pytest.raises(ForbiddenError) as excinfo:
+        await dep(key)
+    assert "sn_" not in str(excinfo.value)
+    assert str(key.id) not in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------------------
+# A2A-style key: must keep working across every scope it is documented to carry
+# --------------------------------------------------------------------------------------
+async def test_a2a_style_key_satisfies_all_four_required_scopes(_patch_repo):
+    """Mirrors `maybe_create_a2a_api_key` in src/core/bootstrap.py: no expiry, four scopes."""
+    key = _make_key(
+        scopes=["skills:read", "skills:write", "users:read", "courses:write"],
+        expires_at=None,
+    )
+    resolved = await _resolve(_patch_repo, key)
+    for scope in ("skills:read", "skills:write", "users:read", "courses:write"):
+        dep = ext_auth.require_scope(scope)
+        assert await dep(resolved) is resolved
+
+
+async def test_bad_authorization_header_is_rejected(_patch_repo):
+    state = _patch_repo
+    state["key"] = _make_key(scopes=["skills:read"])
+    with pytest.raises(ForbiddenError):
+        await ext_auth._get_api_key(db=_FakeDB(), authorization="Token not-a-bearer")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,6 +188,29 @@ services:
       api:
         condition: service_healthy
 
+  # ── MCP Server (optional) ────────────────────────────────────
+  # Thin Streamable HTTP wrapper over /ext/v1 for MCP-speaking AI clients. Never
+  # touches PostgreSQL; see docs/design/mcp-external-api.md (8.8-8.9) and
+  # packages/skillnet-mcp/README.md.
+  mcp:
+    build:
+      context: .
+      dockerfile: packages/skillnet-mcp/Dockerfile
+    restart: unless-stopped
+    profiles: [mcp]
+    ports:
+      - "127.0.0.1:${SKILLNET_MCP_PORT:-3001}:3001"
+    environment:
+      SKILLNET_API_URL: http://api:8000
+      # Optional: a default API key used when a connecting client sends no
+      # Authorization header of its own. Leave unset to require every client to
+      # supply its own SkillNet API key.
+      SKILLNET_API_KEY: ${SKILLNET_MCP_API_KEY:-}
+      MCP_HTTP_PORT: "3001"
+    depends_on:
+      api:
+        condition: service_healthy
+
   # ── Frontend (nginx + React SPA) ───────────────────────────
   web:
     build:

--- a/packages/skillnet-mcp/.env.example
+++ b/packages/skillnet-mcp/.env.example
@@ -1,0 +1,17 @@
+# Base URL of the SkillNet FastAPI backend. Required.
+SKILLNET_API_URL=http://localhost:8000
+
+# Optional fallback SkillNet API key (sn_...), used only when an incoming MCP request
+# doesn't carry its own Authorization header — convenient for a single-tenant / local
+# setup. Remote clients normally send their own key instead; see README.md.
+# SKILLNET_API_KEY=
+
+# Port the Streamable HTTP transport listens on.
+MCP_HTTP_PORT=3001
+
+# Timeout (ms) for ordinary read calls (list_skills, who_knows, get_gap, get_user_skills).
+SKILLNET_REQUEST_TIMEOUT_MS=30000
+
+# Timeout (ms) for create_course, which runs the full authoring pipeline server-side
+# and can take minutes on a real LLM provider.
+SKILLNET_CREATE_COURSE_TIMEOUT_MS=600000

--- a/packages/skillnet-mcp/Dockerfile
+++ b/packages/skillnet-mcp/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+# skillnet-mcp — MCP server, thin Streamable HTTP wrapper over /ext/v1.
+# Build context is the repo root (matches docker/a2a.Dockerfile's convention).
+
+FROM node:20-slim AS builder
+WORKDIR /app
+COPY packages/skillnet-mcp/package.json packages/skillnet-mcp/package-lock.json* ./
+RUN npm install
+COPY packages/skillnet-mcp/tsconfig.json ./
+COPY packages/skillnet-mcp/src ./src
+RUN npm run build
+
+FROM node:20-slim AS runtime
+RUN groupadd -r skillnet && useradd -r -g skillnet -d /app -s /sbin/nologin skillnet
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/package.json /app/package-lock.json* ./
+RUN npm install --omit=dev
+COPY --from=builder /app/dist ./dist
+RUN chown -R skillnet:skillnet /app
+USER skillnet
+EXPOSE 3001
+CMD ["node", "dist/index.js"]

--- a/packages/skillnet-mcp/README.md
+++ b/packages/skillnet-mcp/README.md
@@ -1,0 +1,130 @@
+# skillnet-mcp
+
+An MCP (Model Context Protocol) server for SkillNet. It is a thin Streamable HTTP
+wrapper over the existing external API (`/ext/v1`) — it never talks to PostgreSQL
+directly and never duplicates business logic. Every tool call is a plain HTTP request
+to the SkillNet backend, authenticated with a SkillNet API key.
+
+See `docs/design/mcp-external-api.md` (sections 8.8 and 8.9) in the repo root for the
+design this implements.
+
+## Tools
+
+| Tool | Read-only | Wraps |
+|------|-----------|-------|
+| `list_skills` | yes | `GET /ext/v1/skills` |
+| `who_knows` | yes | `GET /ext/v1/skills/who-knows` |
+| `get_gap` | yes | `GET /ext/v1/skills/gaps` |
+| `get_user_skills` | yes | `GET /ext/v1/users/{id}/skills` |
+| `create_course` | no | `POST /ext/v1/courses/full` |
+
+`verify_skill` is intentionally **not** exposed as a tool in this version — see
+`src/server.ts` for why.
+
+## Scopes required
+
+The SkillNet API key used to connect must carry:
+
+- `skills:read` and `users:read` for the read-only tools.
+- `courses:write` for `create_course`.
+
+An API key missing a scope gets a `403` back from `/ext/v1`, which surfaces as a tool
+error — the model never gets a silent wrong answer.
+
+## Running it
+
+```bash
+cd packages/skillnet-mcp
+npm install
+cp .env.example .env   # then set SKILLNET_API_URL, optionally SKILLNET_API_KEY
+npm run build
+npm start
+```
+
+The server listens on `http://0.0.0.0:3001/mcp` (Streamable HTTP; **no SSE
+transport**). Requests without their own `Authorization` header fall back to
+`SKILLNET_API_KEY` from the environment, if set.
+
+### Via Docker Compose
+
+From the repo root:
+
+```bash
+docker compose --profile mcp up -d --build mcp
+```
+
+This builds the image from `packages/skillnet-mcp/Dockerfile` and starts it on
+`127.0.0.1:3001`, pointed at the `api` service over the compose network. Set
+`SKILLNET_MCP_API_KEY` in your `.env` to give it a default key (see
+`docker-compose.yml`'s `mcp` service).
+
+## Connecting an MCP client
+
+Any client that speaks MCP over Streamable HTTP can connect. Point it at
+`http://<host>:3001/mcp` and send the SkillNet API key as a bearer token:
+
+```
+Authorization: Bearer sn_your_real_key_here
+```
+
+Example with the TypeScript SDK's client:
+
+```ts
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const transport = new StreamableHTTPClientTransport(
+  new URL("http://localhost:3001/mcp"),
+  { requestInit: { headers: { authorization: "Bearer sn_your_real_key_here" } } }
+);
+const client = new Client({ name: "example-client", version: "1.0.0" });
+await client.connect(transport);
+const tools = await client.listTools();
+```
+
+Or with `mcp-remote` for a client that only supports stdio (e.g. an older Claude
+Desktop):
+
+```json
+{
+  "mcpServers": {
+    "skillnet": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "http://localhost:3001/mcp",
+        "--header",
+        "Authorization: Bearer sn_your_real_key_here"
+      ]
+    }
+  }
+}
+```
+
+## Getting a SkillNet API key
+
+Create one from the admin panel (`/admin/settings/api-keys`) with, at minimum,
+`skills:read` and `users:read` scopes for the read-only tools, plus `courses:write` if
+`create_course` is needed. Keys can carry an expiry (`expires_at`); an expired or
+scope-missing key is rejected by `/ext/v1` with a `403`.
+
+## Development
+
+```bash
+npm install
+npm run typecheck   # tsc --noEmit
+npm run build       # tsc -> dist/
+npm test            # vitest, all HTTP calls mocked — never hits a real server
+```
+
+## Design notes / limitations
+
+- Stateless per request: each HTTP request gets its own `McpServer` instance bound to
+  the API key resolved for that request (its own `Authorization` header, or the
+  server's `SKILLNET_API_KEY` fallback). No session state, no shared credentials
+  across connections.
+- No OAuth, no MCP "Apps" UI, no connector directory listing — out of scope for this
+  version. See `docs/design/mcp-external-api.md` 8.8.6–8.8.8 for what that would take.
+- `create_course` can take minutes and can return honestly incomplete results
+  (`packs_all_ready: false`, non-empty `warnings`) — that's the real behaviour of
+  `POST /ext/v1/courses/full`, not a bug in this wrapper.

--- a/packages/skillnet-mcp/package-lock.json
+++ b/packages/skillnet-mcp/package-lock.json
@@ -1,0 +1,2641 @@
+{
+  "name": "skillnet-mcp",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "skillnet-mcp",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.30.0",
+        "zod": "^3.25.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.5.tgz",
+      "integrity": "sha512-jfkGfTwhQpsiSckPF8r9bU3pn3vyd72NlWaO+TgEO6WPSDnUhXzrNYCHBMOYj0ACaUgjm6eERLF+XV9a6RstoA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.5.tgz",
+      "integrity": "sha512-oGVqyQlxnrz9/ty89oHpU857VUHEl5/Xu4R2lS+aivCTrNnSsbiENzTnNaBsjxH0CNWGPhzHArOLFwo+oKXveA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.5.tgz",
+      "integrity": "sha512-bW7B8xMEq8n99Q3ieEcPRGuphurdZAaFzQc9Efyyw3FL6DZO6pMy9xhdN+kBoD7Sy05xNXSr4OyPPnpkYriS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.5.tgz",
+      "integrity": "sha512-YSwBS86QeHOGlrxJ1PSOIZSkzRL/JmKeunhc+lV6M1a6En8QuVCD/T/qIA0J4Gd2Y86RIOBYrLcOUtqGh9+/1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.5.tgz",
+      "integrity": "sha512-2fST8lILgl7cKbme/1KDdPCmbXbG+gqoV3bHp19L0ypX/3akYMBVdOunPleRCwonoLnXOZ/0F+Mt/v8POFmfcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.5.tgz",
+      "integrity": "sha512-cpIxQCP9J+EVad0a6LO1kY3ZGODlk80VlI+2I96B8xMcdHZ4pLVhfQ49JFpYqjPF91FFkQWftf57YlDcTiw9yQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.5.tgz",
+      "integrity": "sha512-r9fGh3eFs3e/udWh5ZjXQtxiYK/xoFxQaYR/cELxac/Udkl5Th+IsFm0CX3Kl9hmUH/we7EoMpjJgeQNnE0+IA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.5.tgz",
+      "integrity": "sha512-xdvFdp7OM6KLJviJT2g/YuRSUjnZgGHk4RNgwIbN7X6cPugOucV60DdHXWzsBVCUdrGb6qSXnJQrrAKMmQuj3Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.5.tgz",
+      "integrity": "sha512-rRqILAndyzHzP7T9NFQrq+4HFWNhqkqkKur7eiBpfLmz01PO0JKx5Vchu3YllE4YXI/Ftgq/szrDWg5GJ0mI8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.5.tgz",
+      "integrity": "sha512-Gf4X3qVMucayUvux6aXXPgXovocSFUC0rrffDuPI/S2nHhNMhjcZxsrAFYCOF350PRreW1XwzFj3CT/3bKsWCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.5.tgz",
+      "integrity": "sha512-+s5qA0TNM0qm8PK/a5gt/1Hpx+NV08uSuCncvhziIlQzT6AEV2fnUQo7eBtFTFO0nA9scauvoR2HusfXmQnO4w==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.5.tgz",
+      "integrity": "sha512-ybb6QvWwWJCbBWqERpc8K3pYVGIrXlG8MEQ8IIuJY6Y9KdHQxoFoNyfkAOtKn1VHu3KuLidXvwrvGR1mEjeWCw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.5.tgz",
+      "integrity": "sha512-nZb1DtnOyhCmYvsC8A2CwOkopVg+IS1+fPUa7rMOAXtNw5+lLCLLPqd6XAiNrGtoQKsbvIBOwsHnBH/3wnb4HQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.5.tgz",
+      "integrity": "sha512-yMbj63Sp89ryrXLWyz+sy+fYD2HpOnMCLGbe4Oa1smclFSUukdtD/BgdiHaAetJNb74URD8U4hM+qG5KVzMEkg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.5.tgz",
+      "integrity": "sha512-mhoan3OJw2kYV/e1jtIdmvUZgyBFeA6zGWsOswmR0Tg19TQbowZuR+JMLID6spbbBN7Zee2ejrgmy3+FxGrIdA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.5.tgz",
+      "integrity": "sha512-5ZTLmjWbb1VZdjuyhe83K/8QO0/h11midQCBP+X5OYn32ra7eOBoM0ZqtaY4nkgNsYgmdVhMYPoyVPTjUpHf3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.5.tgz",
+      "integrity": "sha512-m53kG+br6PGxOTmgBEM2DHSDs9RVjsyEbUwjJPJGTFm1grWOG8EKJggDCTb60unD4Tjby8fi7/m9XfkEWasVWg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.5.tgz",
+      "integrity": "sha512-6RHPJR1g/uvdYU8uXBnfq3nlqyZCP82Fr6NHgfGoaIeSh0YEqnX/x6uA9MmJJbnSH7swqX4F+CkGdUF+6doiQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.5.tgz",
+      "integrity": "sha512-xs+OXQtEXgpXT0DmA5+U3qnRZHdCST/5HRQxS8wSPZTUZN/EMWeHuSIod32LQklTBZBV9DyfncKBQ8n5V3eFdw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.5.tgz",
+      "integrity": "sha512-e7hD+sl3s+mcLQDZ8pbudBVsdG6r5yN4w3LqG2TJ8sQHDpblWj5lrJs/3m01Cvlxbt4x13zu5thLjgypgtkYzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.5.tgz",
+      "integrity": "sha512-GiyJaCf+WpMub/17aPcKk27QMl5W6f+KhdPTjlFOn5akH5Wa/DCM9Stdx5cDfmasyKB08MqpVQ1uJE2RkkpbXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.5.tgz",
+      "integrity": "sha512-+OQ8U2DdoEfXl8T4Fb18AjmEwbXMerKDKCL8yCPAYhKCEEKoul7rkbeGCBFCbAlaGaa7pmtRTpkAJM2LE/i5FA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.5.tgz",
+      "integrity": "sha512-KanvAZrPKbDBFwrgiU9yEVpQoox9QPV1WZOXX7HudJQY+eSlu82CtWxDU8WtuRRvtN5EGkLczkd6Y6DTcvm9wA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.5.tgz",
+      "integrity": "sha512-1aC3UEWTtRl3RK3VpDJ/Tqk1XI4SLTmXIthAq6wRWo8XiSXJNd+VprJM4/1P4+i6HIaFEFlVi9sTTziniD2tOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.5.tgz",
+      "integrity": "sha512-/gDJaRs4gl0NPIwqCz+6PkpmhhjRAD2j6P4rSNHBzUkO3naEx2mIU0pRle1vUNRQ7mE/+8OOeXLTv/J56FKiQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.4.tgz",
+      "integrity": "sha512-AGEwKIyRMHRv1t8Wjwa3LHxQ61X5CqrdFT+4BRNTpqS5aJNnpl5WLjADb7vFlJzI/8uK7T5QLVApCMQKNa3LgQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.10.tgz",
+      "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.5.tgz",
+      "integrity": "sha512-/tqMfgP7GPA3PHhCmuiS4vIjrSVhHLgY++i+dhbG462euyAj7FpM4D9uq1X3BgjlqRdpcOrYhcQtfiQLNc8tqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.5",
+        "@rollup/rollup-android-arm64": "4.62.5",
+        "@rollup/rollup-darwin-arm64": "4.62.5",
+        "@rollup/rollup-darwin-x64": "4.62.5",
+        "@rollup/rollup-freebsd-arm64": "4.62.5",
+        "@rollup/rollup-freebsd-x64": "4.62.5",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.5",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.5",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.5",
+        "@rollup/rollup-linux-arm64-musl": "4.62.5",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.5",
+        "@rollup/rollup-linux-loong64-musl": "4.62.5",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.5",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.5",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.5",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.5",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.5",
+        "@rollup/rollup-linux-x64-gnu": "4.62.5",
+        "@rollup/rollup-linux-x64-musl": "4.62.5",
+        "@rollup/rollup-openbsd-x64": "4.62.5",
+        "@rollup/rollup-openharmony-arm64": "4.62.5",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.5",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.5",
+        "@rollup/rollup-win32-x64-gnu": "4.62.5",
+        "@rollup/rollup-win32-x64-msvc": "4.62.5",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/packages/skillnet-mcp/package.json
+++ b/packages/skillnet-mcp/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "skillnet-mcp",
+  "version": "0.1.0",
+  "description": "MCP server for SkillNet — a thin Streamable HTTP wrapper over the /ext/v1 external API, exposing skills data as MCP tools for AI agents.",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsc && node dist/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^2.1.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/skillnet-mcp/src/config.ts
+++ b/packages/skillnet-mcp/src/config.ts
@@ -1,0 +1,42 @@
+/** Environment-driven configuration. Read once at process start. */
+
+export interface McpConfig {
+  /** Base URL of the SkillNet FastAPI backend, e.g. http://localhost:8000. */
+  apiUrl: string;
+  /**
+   * Fallback SkillNet API key, used only when an incoming MCP request carries no
+   * `Authorization` header of its own (the common case for a local stdio-style client
+   * pointed at a single-tenant instance). A per-request `Authorization` header always
+   * takes priority — see `resolveApiKey` in `http.ts`.
+   */
+  defaultApiKey: string | undefined;
+  /** Port the Streamable HTTP transport listens on. */
+  port: number;
+  /** Timeout (ms) for ordinary read calls against /ext/v1. */
+  requestTimeoutMs: number;
+  /** Timeout (ms) for `create_course`, which runs the full authoring pipeline server-side. */
+  createCourseTimeoutMs: number;
+}
+
+function readConfig(env: NodeJS.ProcessEnv): McpConfig {
+  const apiUrl = env.SKILLNET_API_URL?.trim();
+  if (!apiUrl) {
+    throw new Error(
+      "SKILLNET_API_URL is required (base URL of the SkillNet API, e.g. http://localhost:8000)"
+    );
+  }
+  return {
+    apiUrl: apiUrl.replace(/\/+$/, ""),
+    defaultApiKey: env.SKILLNET_API_KEY?.trim() || undefined,
+    port: Number.parseInt(env.MCP_HTTP_PORT ?? "3001", 10),
+    requestTimeoutMs: Number.parseInt(env.SKILLNET_REQUEST_TIMEOUT_MS ?? "30000", 10),
+    createCourseTimeoutMs: Number.parseInt(
+      env.SKILLNET_CREATE_COURSE_TIMEOUT_MS ?? "600000",
+      10
+    ),
+  };
+}
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): McpConfig {
+  return readConfig(env);
+}

--- a/packages/skillnet-mcp/src/errors.ts
+++ b/packages/skillnet-mcp/src/errors.ts
@@ -1,0 +1,91 @@
+/**
+ * Turns a failed call to /ext/v1 into a message safe to hand back to an MCP client.
+ *
+ * Never includes the `Authorization` header or the raw API key — only the SkillNet
+ * error envelope (`error` / `message` / `details`, see docs/design/mcp-external-api.md
+ * 8.1.6) or, failing that, the HTTP status and a generic description.
+ */
+export class SkillNetApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly body: unknown
+  ) {
+    super(message);
+    this.name = "SkillNetApiError";
+  }
+}
+
+export async function toApiError(response: Response): Promise<SkillNetApiError> {
+  let parsed: unknown;
+  try {
+    parsed = await response.json();
+  } catch {
+    parsed = undefined;
+  }
+
+  if (isErrorEnvelope(parsed)) {
+    const suffix = parsed.details ? ` (${safeStringify(parsed.details)})` : "";
+    return new SkillNetApiError(
+      `SkillNet API error [${parsed.error}]: ${parsed.message}${suffix}`,
+      response.status,
+      parsed
+    );
+  }
+
+  return new SkillNetApiError(
+    describeStatus(response.status),
+    response.status,
+    parsed
+  );
+}
+
+function isErrorEnvelope(
+  value: unknown
+): value is { error: string; message: string; details?: unknown } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "error" in value &&
+    "message" in value &&
+    typeof (value as { message?: unknown }).message === "string"
+  );
+}
+
+function describeStatus(status: number): string {
+  switch (status) {
+    case 401:
+      return "The SkillNet API rejected the credential (401 unauthorized).";
+    case 403:
+      return "The SkillNet API key lacks the required scope for this call (403 forbidden).";
+    case 404:
+      return "The requested resource was not found in SkillNet (404).";
+    case 422:
+      return "SkillNet rejected the request as invalid (422).";
+    case 429:
+      return "Rate limit exceeded on the SkillNet API (429). Retry later.";
+    default:
+      return `SkillNet API request failed with status ${status}.`;
+  }
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/** Formats any thrown error into a plain string, safe for a tool's error content. */
+export function describeError(error: unknown): string {
+  if (error instanceof SkillNetApiError) {
+    return error.message;
+  }
+  if (error instanceof Error) {
+    // Fetch network errors, JSON parse errors, etc. Their .message never carries the
+    // Authorization header (Node's fetch does not echo request headers in errors).
+    return `SkillNet request failed: ${error.message}`;
+  }
+  return "SkillNet request failed with an unknown error.";
+}

--- a/packages/skillnet-mcp/src/http.ts
+++ b/packages/skillnet-mcp/src/http.ts
@@ -1,0 +1,103 @@
+import { createServer as createHttpServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { createSkillNetMcpServer } from "./server.js";
+import type { McpConfig } from "./config.js";
+
+/**
+ * Extracts the SkillNet API key to use for this MCP connection.
+ *
+ * Prefers the request's own `Authorization: Bearer <key>` (or a bare `X-Api-Key`
+ * header) — the normal case for a remote client, each with its own SkillNet API key
+ * and its own scopes. Falls back to `SKILLNET_API_KEY` from the environment, for a
+ * single-tenant / local setup where the operator configured one key for the whole
+ * server. Never logs or echoes whatever it resolves.
+ */
+export function resolveApiKey(req: IncomingMessage, config: McpConfig): string | undefined {
+  const auth = req.headers["authorization"];
+  if (typeof auth === "string" && auth.toLowerCase().startsWith("bearer ")) {
+    const token = auth.slice(7).trim();
+    if (token) return token;
+  }
+  const apiKeyHeader = req.headers["x-api-key"];
+  if (typeof apiKeyHeader === "string" && apiKeyHeader.trim()) {
+    return apiKeyHeader.trim();
+  }
+  return config.defaultApiKey;
+}
+
+function sendJsonError(res: ServerResponse, status: number, message: string): void {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      error: { code: -32001, message },
+      id: null,
+    })
+  );
+}
+
+/**
+ * Starts the Streamable HTTP listener. Stateless by design: every request gets its
+ * own `McpServer` + transport bound to the API key resolved for that request, so two
+ * clients (or the same client rotating keys) never share tool state or credentials.
+ */
+export function startHttpServer(config: McpConfig): ReturnType<typeof createHttpServer> {
+  const httpServer = createHttpServer((req, res) => {
+    void handleRequest(req, res, config);
+  });
+  httpServer.listen(config.port, () => {
+    // eslint-disable-next-line no-console
+    console.log(`skillnet-mcp listening on http://0.0.0.0:${config.port}/mcp`);
+  });
+  return httpServer;
+}
+
+async function handleRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  config: McpConfig
+): Promise<void> {
+  if (req.url !== "/mcp" && req.url !== "/") {
+    res.writeHead(404).end();
+    return;
+  }
+  if (req.method !== "POST" && req.method !== "GET" && req.method !== "DELETE") {
+    res.writeHead(405).end();
+    return;
+  }
+
+  const apiKey = resolveApiKey(req, config);
+  if (!apiKey) {
+    sendJsonError(
+      res,
+      401,
+      "Missing SkillNet API key: send it as 'Authorization: Bearer <key>' or configure " +
+        "SKILLNET_API_KEY on the server."
+    );
+    return;
+  }
+
+  const server = createSkillNetMcpServer({
+    apiUrl: config.apiUrl,
+    apiKey,
+    requestTimeoutMs: config.requestTimeoutMs,
+    createCourseTimeoutMs: config.createCourseTimeoutMs,
+  });
+  const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+
+  res.on("close", () => {
+    void transport.close();
+    void server.close();
+  });
+
+  try {
+    await server.connect(transport);
+    await transport.handleRequest(req, res);
+  } catch (error) {
+    if (!res.headersSent) {
+      sendJsonError(res, 500, "Internal MCP server error.");
+    }
+    // eslint-disable-next-line no-console
+    console.error("skillnet-mcp request failed:", error instanceof Error ? error.message : error);
+  }
+}

--- a/packages/skillnet-mcp/src/index.ts
+++ b/packages/skillnet-mcp/src/index.ts
@@ -1,0 +1,13 @@
+import { loadConfig } from "./config.js";
+import { startHttpServer } from "./http.js";
+
+export { createSkillNetMcpServer } from "./server.js";
+export { SkillNetClient } from "./skillnetClient.js";
+export { loadConfig } from "./config.js";
+
+function main(): void {
+  const config = loadConfig();
+  startHttpServer(config);
+}
+
+main();

--- a/packages/skillnet-mcp/src/server.ts
+++ b/packages/skillnet-mcp/src/server.ts
@@ -1,0 +1,32 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { SkillNetClient, type SkillNetClientOptions } from "./skillnetClient.js";
+import { registerListSkills } from "./tools/listSkills.js";
+import { registerWhoKnows } from "./tools/whoKnows.js";
+import { registerGetGap } from "./tools/getGap.js";
+import { registerGetUserSkills } from "./tools/getUserSkills.js";
+import { registerCreateCourse } from "./tools/createCourse.js";
+
+/**
+ * Builds one MCP server instance wired to a SkillNet API key.
+ *
+ * `verify_skill` is deliberately not registered here: it is the one write endpoint
+ * that exists on `/ext/v1`, and this MVP does not expose it as a model-callable tool.
+ * See docs/design/mcp-external-api.md 8.8.4 for why (a model should not be able to
+ * change what an employee is recorded as knowing without a human in the loop).
+ */
+export function createSkillNetMcpServer(clientOptions: SkillNetClientOptions): McpServer {
+  const server = new McpServer({
+    name: "skillnet-mcp",
+    version: "0.1.0",
+  });
+
+  const client = new SkillNetClient(clientOptions);
+
+  registerListSkills(server, client);
+  registerWhoKnows(server, client);
+  registerGetGap(server, client);
+  registerGetUserSkills(server, client);
+  registerCreateCourse(server, client);
+
+  return server;
+}

--- a/packages/skillnet-mcp/src/skillnetClient.ts
+++ b/packages/skillnet-mcp/src/skillnetClient.ts
@@ -1,0 +1,188 @@
+/**
+ * Thin HTTP client for `/ext/v1`. This is the ONLY way this package talks to
+ * SkillNet: plain `fetch` calls against the FastAPI backend, carrying the caller's
+ * API key as a Bearer token. No PostgreSQL driver, no direct database access, no
+ * business logic duplicated from `apps/skillnet-api` — every rule (org scoping, level
+ * validation, gap thresholds, ...) lives server-side and this client just relays it.
+ */
+import { toApiError } from "./errors.js";
+
+export interface SkillCategory {
+  id: string;
+  name: string;
+  skills: Array<{ id: string; name: string; description?: string | null }>;
+}
+
+export interface WhoKnowsResponse {
+  skill: string;
+  employees: Array<{
+    user_id: string;
+    full_name: string;
+    level: string;
+    source: string;
+    last_assessed_at?: string | null;
+  }>;
+  [key: string]: unknown;
+}
+
+export interface GapReport {
+  gaps: Array<{
+    skill: { id: string; name: string; category?: string };
+    total_users: number;
+    users_at_level: number;
+    coverage_ratio: number;
+    gap_severity: string;
+    users_below?: Array<{ id: string; full_name: string; current_level: string }>;
+  }>;
+  [key: string]: unknown;
+}
+
+export interface UserSkill {
+  skill_id: string;
+  skill_name: string;
+  category?: string;
+  level: string;
+  source: string;
+  last_assessed_at?: string | null;
+}
+
+export interface CreateCourseParams {
+  title: string;
+  document_id?: string;
+  intent_density?: number;
+  enroll_user_id?: string;
+  generate_artifacts?: string[];
+  artifact_node_limit?: number;
+}
+
+export interface CreateCourseResult {
+  course_id: string;
+  title: string;
+  schema_status: string;
+  schema_version: number;
+  node_count: number;
+  packs_ready: number;
+  packs_all_ready: boolean;
+  packs_summary: string;
+  nodes: Array<{ node_id: string; title: string; status: string }>;
+  reviewed: boolean;
+  validated: boolean;
+  enrolled_user_id: string | null;
+  prewarm_spawned: boolean;
+  artifacts: Array<{ artifact_id: string; node_id: string; kind: string; status: string }>;
+  warnings: string[];
+  [key: string]: unknown;
+}
+
+export interface SkillNetClientOptions {
+  apiUrl: string;
+  apiKey: string;
+  requestTimeoutMs?: number;
+  createCourseTimeoutMs?: number;
+}
+
+export class SkillNetClient {
+  private readonly apiUrl: string;
+  private readonly apiKey: string;
+  private readonly requestTimeoutMs: number;
+  private readonly createCourseTimeoutMs: number;
+
+  constructor(options: SkillNetClientOptions) {
+    this.apiUrl = options.apiUrl.replace(/\/+$/, "");
+    this.apiKey = options.apiKey;
+    this.requestTimeoutMs = options.requestTimeoutMs ?? 30_000;
+    this.createCourseTimeoutMs = options.createCourseTimeoutMs ?? 600_000;
+  }
+
+  async listSkills(params: { category?: string; search?: string } = {}): Promise<
+    SkillCategory[]
+  > {
+    return this.get("/ext/v1/skills", params, this.requestTimeoutMs);
+  }
+
+  async whoKnows(params: {
+    skill: string;
+    min_level?: string;
+    limit?: number;
+  }): Promise<WhoKnowsResponse> {
+    return this.get("/ext/v1/skills/who-knows", params, this.requestTimeoutMs);
+  }
+
+  async getGap(params: {
+    skill?: string;
+    min_level?: string;
+    threshold?: number;
+  } = {}): Promise<GapReport> {
+    return this.get("/ext/v1/skills/gaps", params, this.requestTimeoutMs);
+  }
+
+  async getUserSkills(userId: string): Promise<UserSkill[]> {
+    return this.get(
+      `/ext/v1/users/${encodeURIComponent(userId)}/skills`,
+      {},
+      this.requestTimeoutMs
+    );
+  }
+
+  async createCourse(params: CreateCourseParams): Promise<CreateCourseResult> {
+    return this.post("/ext/v1/courses/full", params, this.createCourseTimeoutMs);
+  }
+
+  // -- internals ---------------------------------------------------------------------
+
+  private async get<T>(
+    path: string,
+    query: Record<string, string | number | undefined>,
+    timeoutMs: number
+  ): Promise<T> {
+    const url = new URL(this.apiUrl + path);
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined && value !== null) {
+        url.searchParams.set(key, String(value));
+      }
+    }
+    const response = await this.fetchWithTimeout(url, { method: "GET" }, timeoutMs);
+    if (!response.ok) {
+      throw await toApiError(response);
+    }
+    return (await response.json()) as T;
+  }
+
+  private async post<T>(path: string, body: unknown, timeoutMs: number): Promise<T> {
+    const url = new URL(this.apiUrl + path);
+    const response = await this.fetchWithTimeout(
+      url,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      },
+      timeoutMs
+    );
+    if (!response.ok) {
+      throw await toApiError(response);
+    }
+    return (await response.json()) as T;
+  }
+
+  private async fetchWithTimeout(
+    url: URL,
+    init: RequestInit,
+    timeoutMs: number
+  ): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      return await fetch(url, {
+        ...init,
+        signal: controller.signal,
+        headers: {
+          ...(init.headers ?? {}),
+          authorization: `Bearer ${this.apiKey}`,
+        },
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/packages/skillnet-mcp/src/tools/createCourse.ts
+++ b/packages/skillnet-mcp/src/tools/createCourse.ts
@@ -1,0 +1,94 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { SkillNetClient } from "../skillnetClient.js";
+import { describeError } from "../errors.js";
+
+const inputSchema = {
+  title: z.string().min(1).max(300).describe("Title of the course to create."),
+  document_id: z
+    .string()
+    .optional()
+    .describe(
+      "Optional id of an already-processed document (status='ready') to ground the " +
+        "course schema on. Without it, the course is synthesized from the title alone."
+    ),
+  intent_density: z
+    .number()
+    .int()
+    .min(1)
+    .max(5)
+    .optional()
+    .describe("Depth of the generated course, 1 (shallow) to 5 (deep). Defaults to 3."),
+  enroll_user_id: z
+    .string()
+    .optional()
+    .describe("Optional employee user id to enroll in the course once it's ready."),
+  generate_artifacts: z
+    .array(z.enum(["podcast", "infographic"]))
+    .optional()
+    .describe("Media artifacts to generate for the first nodes, e.g. ['podcast']."),
+  artifact_node_limit: z
+    .number()
+    .int()
+    .min(0)
+    .max(10)
+    .optional()
+    .describe("Max number of nodes to generate artifacts for. Defaults to 1."),
+};
+
+export function registerCreateCourse(server: McpServer, client: SkillNetClient): void {
+  server.registerTool(
+    "create_course",
+    {
+      title: "Create a course",
+      description:
+        "Create a full dynamic SkillNet course end to end in one call: propose the " +
+        "schema, generate the knowledge packs (with automatic retries), review every " +
+        "node, validate the course, and warm the first renders. Optionally enroll an " +
+        "employee and generate artifacts (podcast, infographic). This can take several " +
+        "minutes on a real LLM provider, and it can succeed partially — some knowledge " +
+        "packs may still be generating in the background when this returns. Check " +
+        "'packs_all_ready' and 'warnings' in the result rather than assuming full success.",
+      inputSchema,
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async (args) => {
+      try {
+        const result = await client.createCourse(args);
+        const lines: string[] = [
+          `Course '${result.title}' created (id ${result.course_id}).`,
+          `Schema: ${result.schema_status}, ${result.node_count} node(s).`,
+          `Knowledge packs: ${result.packs_summary}` +
+            (result.packs_all_ready ? "" : " — not all ready yet, generation continues in the background."),
+          `Validated: ${result.validated ? "yes" : "no"}.`,
+        ];
+        if (result.enrolled_user_id) {
+          lines.push(`Enrolled user: ${result.enrolled_user_id}.`);
+        }
+        if (result.artifacts?.length) {
+          lines.push(
+            `Artifacts requested: ${result.artifacts
+              .map((a) => `${a.kind} (${a.status})`)
+              .join(", ")}.`
+          );
+        }
+        if (result.warnings?.length) {
+          lines.push(`Warnings: ${result.warnings.join("; ")}`);
+        }
+        return {
+          content: [{ type: "text", text: lines.join("\n") }],
+          structuredContent: result,
+          // Not an MCP protocol error even when the course only partially converged —
+          // the call succeeded and returned honest, structured partial-success data.
+          // A caller that wants to treat "not fully ready" as failure should inspect
+          // packs_all_ready / validated / warnings above.
+        };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: describeError(error) }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/packages/skillnet-mcp/src/tools/getGap.ts
+++ b/packages/skillnet-mcp/src/tools/getGap.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { SkillNetClient } from "../skillnetClient.js";
+import { describeError } from "../errors.js";
+
+const inputSchema = {
+  skill: z
+    .string()
+    .optional()
+    .describe("Look at gaps for this specific skill only. Omit to see all gaps."),
+  min_level: z
+    .enum(["low", "medium", "high"])
+    .optional()
+    .describe("Minimum level considered 'covered'. Defaults to 'medium'."),
+  threshold: z
+    .number()
+    .min(0)
+    .max(1)
+    .optional()
+    .describe(
+      "Coverage ratio (0-1) below which a skill counts as a gap. Defaults to 0.5."
+    ),
+};
+
+export function registerGetGap(server: McpServer, client: SkillNetClient): void {
+  server.registerTool(
+    "get_gap",
+    {
+      title: "Analyze skill gaps",
+      description:
+        "Analyze skill gaps in the organization: skills the company needs but where " +
+        "too few employees are covered at the minimum level. Use this when someone " +
+        "asks 'what skills are we missing?' or 'who needs training in X?'. Returns " +
+        "each gap's severity (critical/warning/moderate) and the coverage ratio.",
+      inputSchema,
+      annotations: { readOnlyHint: true },
+    },
+    async (args) => {
+      try {
+        const result = await client.getGap(args);
+        const text =
+          result.gaps.length === 0
+            ? "No skill gaps detected."
+            : result.gaps
+                .map(
+                  (g) =>
+                    `- ${g.skill.name} (${g.gap_severity}): ${g.users_at_level}/${g.total_users} ` +
+                    `covered (${Math.round(g.coverage_ratio * 100)}%)`
+                )
+                .join("\n");
+        return {
+          content: [{ type: "text", text }],
+          structuredContent: result,
+        };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: describeError(error) }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/packages/skillnet-mcp/src/tools/getUserSkills.ts
+++ b/packages/skillnet-mcp/src/tools/getUserSkills.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { SkillNetClient } from "../skillnetClient.js";
+import { describeError } from "../errors.js";
+
+const inputSchema = {
+  user_id: z
+    .string()
+    .min(1)
+    .describe("The employee's SkillNet user id (UUID)."),
+};
+
+export function registerGetUserSkills(server: McpServer, client: SkillNetClient): void {
+  server.registerTool(
+    "get_user_skills",
+    {
+      title: "Get an employee's skills",
+      description:
+        "Get the complete skill profile for one employee: every skill they have, its " +
+        "level, how it was assessed, and when. Use this when someone asks 'what does " +
+        "X know?' or 'show me X's skill profile'. Requires the employee's user id — " +
+        "use who_knows or the SkillNet admin panel to find it if you only have a name.",
+      inputSchema,
+      annotations: { readOnlyHint: true },
+    },
+    async (args) => {
+      try {
+        const skills = await client.getUserSkills(args.user_id);
+        const counts = { low: 0, medium: 0, high: 0 };
+        for (const s of skills) {
+          if (s.level in counts) counts[s.level as keyof typeof counts] += 1;
+        }
+        const text =
+          skills.length === 0
+            ? "This employee has no recorded skills yet."
+            : `${skills.length} skill(s) (${counts.high} high, ${counts.medium} medium, ` +
+              `${counts.low} low):\n` +
+              skills.map((s) => `- ${s.skill_name}: ${s.level}`).join("\n");
+        return {
+          content: [{ type: "text", text }],
+          structuredContent: { skills, summary: { ...counts, total: skills.length } },
+        };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: describeError(error) }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/packages/skillnet-mcp/src/tools/listSkills.ts
+++ b/packages/skillnet-mcp/src/tools/listSkills.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { SkillNetClient } from "../skillnetClient.js";
+import { describeError } from "../errors.js";
+
+const inputSchema = {
+  category: z
+    .string()
+    .optional()
+    .describe("Filter to skills in this category name only."),
+  search: z
+    .string()
+    .optional()
+    .describe("Filter to skills whose name matches this search term."),
+};
+
+export function registerListSkills(server: McpServer, client: SkillNetClient): void {
+  server.registerTool(
+    "list_skills",
+    {
+      title: "List skills",
+      description:
+        "List every skill tracked by this SkillNet organization, grouped by category. " +
+        "Use this first to see what skills exist before calling who_knows, get_gap, or " +
+        "get_user_skills with a specific skill name.",
+      inputSchema,
+      annotations: { readOnlyHint: true },
+    },
+    async (args) => {
+      try {
+        const categories = await client.listSkills(args);
+        const totalSkills = categories.reduce((sum, c) => sum + c.skills.length, 0);
+        const summary = categories
+          .map((c) => `${c.name}: ${c.skills.map((s) => s.name).join(", ")}`)
+          .join("\n");
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                totalSkills === 0
+                  ? "No skills found for this organization."
+                  : `${totalSkills} skill(s) across ${categories.length} categor${
+                      categories.length === 1 ? "y" : "ies"
+                    }:\n${summary}`,
+            },
+          ],
+          structuredContent: { categories, total_skills: totalSkills },
+        };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: describeError(error) }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/packages/skillnet-mcp/src/tools/whoKnows.ts
+++ b/packages/skillnet-mcp/src/tools/whoKnows.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { SkillNetClient } from "../skillnetClient.js";
+import { describeError } from "../errors.js";
+
+const inputSchema = {
+  skill: z.string().min(1).describe("Name of the skill to search for, e.g. 'python'."),
+  min_level: z
+    .enum(["low", "medium", "high"])
+    .optional()
+    .describe("Minimum skill level to include. Defaults to 'low' (any level)."),
+};
+
+export function registerWhoKnows(server: McpServer, client: SkillNetClient): void {
+  server.registerTool(
+    "who_knows",
+    {
+      title: "Who knows a skill",
+      description:
+        "Find employees who have a specific skill at or above a minimum level. " +
+        "Use this when someone asks 'who can do X?' or 'who knows X?'. Returns each " +
+        "matching employee's level, how the level was assessed (checkpoint vs manual), " +
+        "and when it was last assessed.",
+      inputSchema,
+      annotations: { readOnlyHint: true },
+    },
+    async (args) => {
+      try {
+        const result = await client.whoKnows(args);
+        const text =
+          result.employees.length === 0
+            ? `No one in this organization has '${result.skill}' at or above the requested level.`
+            : `${result.employees.length} employee(s) know '${result.skill}':\n` +
+              result.employees
+                .map((e) => `- ${e.full_name}: ${e.level} (source: ${e.source})`)
+                .join("\n");
+        return {
+          content: [{ type: "text", text }],
+          structuredContent: result,
+        };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: describeError(error) }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/packages/skillnet-mcp/tests/config.test.ts
+++ b/packages/skillnet-mcp/tests/config.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { loadConfig } from "../src/config.js";
+
+describe("loadConfig", () => {
+  it("requires SKILLNET_API_URL", () => {
+    expect(() => loadConfig({} as NodeJS.ProcessEnv)).toThrow(/SKILLNET_API_URL/);
+  });
+
+  it("strips a trailing slash from the API URL", () => {
+    const config = loadConfig({ SKILLNET_API_URL: "http://localhost:8000/" } as NodeJS.ProcessEnv);
+    expect(config.apiUrl).toBe("http://localhost:8000");
+  });
+
+  it("applies documented defaults", () => {
+    const config = loadConfig({ SKILLNET_API_URL: "http://localhost:8000" } as NodeJS.ProcessEnv);
+    expect(config.port).toBe(3001);
+    expect(config.defaultApiKey).toBeUndefined();
+    expect(config.requestTimeoutMs).toBe(30000);
+    expect(config.createCourseTimeoutMs).toBe(600000);
+  });
+
+  it("reads overrides from the environment", () => {
+    const config = loadConfig({
+      SKILLNET_API_URL: "http://localhost:8000",
+      SKILLNET_API_KEY: "sn_default",
+      MCP_HTTP_PORT: "4000",
+      SKILLNET_REQUEST_TIMEOUT_MS: "1000",
+      SKILLNET_CREATE_COURSE_TIMEOUT_MS: "2000",
+    } as NodeJS.ProcessEnv);
+    expect(config.defaultApiKey).toBe("sn_default");
+    expect(config.port).toBe(4000);
+    expect(config.requestTimeoutMs).toBe(1000);
+    expect(config.createCourseTimeoutMs).toBe(2000);
+  });
+});

--- a/packages/skillnet-mcp/tests/http.test.ts
+++ b/packages/skillnet-mcp/tests/http.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import type { IncomingMessage } from "node:http";
+import { resolveApiKey } from "../src/http.js";
+import type { McpConfig } from "../src/config.js";
+
+function fakeConfig(defaultApiKey?: string): McpConfig {
+  return {
+    apiUrl: "http://localhost:8000",
+    defaultApiKey,
+    port: 3001,
+    requestTimeoutMs: 30000,
+    createCourseTimeoutMs: 600000,
+  };
+}
+
+function fakeRequest(headers: Record<string, string>): IncomingMessage {
+  return { headers } as unknown as IncomingMessage;
+}
+
+describe("resolveApiKey", () => {
+  it("prefers a Bearer Authorization header over the configured default", () => {
+    const req = fakeRequest({ authorization: "Bearer sn_from_request" });
+    expect(resolveApiKey(req, fakeConfig("sn_default"))).toBe("sn_from_request");
+  });
+
+  it("accepts a case-insensitive Bearer prefix", () => {
+    const req = fakeRequest({ authorization: "bearer sn_from_request" });
+    expect(resolveApiKey(req, fakeConfig())).toBe("sn_from_request");
+  });
+
+  it("falls back to X-Api-Key when there is no Authorization header", () => {
+    const req = fakeRequest({ "x-api-key": "sn_header_key" });
+    expect(resolveApiKey(req, fakeConfig())).toBe("sn_header_key");
+  });
+
+  it("falls back to the configured default when the request carries no credential", () => {
+    const req = fakeRequest({});
+    expect(resolveApiKey(req, fakeConfig("sn_default"))).toBe("sn_default");
+  });
+
+  it("returns undefined when neither the request nor the config has a key", () => {
+    const req = fakeRequest({});
+    expect(resolveApiKey(req, fakeConfig())).toBeUndefined();
+  });
+
+  it("ignores a non-Bearer Authorization header and falls through", () => {
+    const req = fakeRequest({ authorization: "Basic abc123" });
+    expect(resolveApiKey(req, fakeConfig("sn_default"))).toBe("sn_default");
+  });
+});

--- a/packages/skillnet-mcp/tests/skillnetClient.test.ts
+++ b/packages/skillnet-mcp/tests/skillnetClient.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { SkillNetClient } from "../src/skillnetClient.js";
+import { SkillNetApiError } from "../src/errors.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("SkillNetClient", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const client = () =>
+    new SkillNetClient({ apiUrl: "http://api.internal:8000", apiKey: "sn_test_secret" });
+
+  it("sends the API key as a Bearer token and never elsewhere", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]));
+    await client().listSkills();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe("http://api.internal:8000/ext/v1/skills");
+    expect(init.headers.authorization).toBe("Bearer sn_test_secret");
+  });
+
+  it("list_skills forwards category/search as query params", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([{ id: "1", name: "Ventas", skills: [] }]));
+    await client().listSkills({ category: "Ventas", search: "dev" });
+
+    const [url] = fetchMock.mock.calls[0];
+    const parsed = new URL(String(url));
+    expect(parsed.searchParams.get("category")).toBe("Ventas");
+    expect(parsed.searchParams.get("search")).toBe("dev");
+  });
+
+  it("who_knows returns the parsed response on success", async () => {
+    const payload = { skill: "python", employees: [{ user_id: "u1", full_name: "Juan", level: "high", source: "manual" }] };
+    fetchMock.mockResolvedValueOnce(jsonResponse(payload));
+
+    const result = await client().whoKnows({ skill: "python" });
+    expect(result).toEqual(payload);
+  });
+
+  it("create_course POSTs the body and uses the long timeout budget", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ course_id: "c1", warnings: [] }));
+    const c = new SkillNetClient({
+      apiUrl: "http://api.internal:8000",
+      apiKey: "sn_test_secret",
+      createCourseTimeoutMs: 600_000,
+    });
+
+    await c.createCourse({ title: "Onboarding" });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe("http://api.internal:8000/ext/v1/courses/full");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({ title: "Onboarding" });
+  });
+
+  it("raises a SkillNetApiError carrying the API's error envelope, not raw internals", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        { error: "not_found", message: "Skill 'blockchain' not found in this organization" },
+        404
+      )
+    );
+
+    await expect(client().whoKnows({ skill: "blockchain" })).rejects.toMatchObject({
+      status: 404,
+      message: expect.stringContaining("blockchain"),
+    });
+  });
+
+  it("raises a generic, safe error when the response has no JSON body", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("plain text failure", { status: 500 }));
+
+    let caught: unknown;
+    try {
+      await client().getGap();
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(SkillNetApiError);
+    expect((caught as SkillNetApiError).status).toBe(500);
+  });
+
+  it("never includes the API key in a thrown error's message", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: "forbidden", message: "nope" }, 403));
+
+    let caught: unknown;
+    try {
+      await client().getUserSkills("u1");
+    } catch (error) {
+      caught = error;
+    }
+    expect(String((caught as Error).message)).not.toContain("sn_test_secret");
+  });
+
+  it("aborts the request once the configured timeout elapses", async () => {
+    fetchMock.mockImplementation((_url: unknown, init: { signal: AbortSignal }) => {
+      return new Promise((_resolve, reject) => {
+        init.signal.addEventListener("abort", () => reject(new Error("aborted")));
+      });
+    });
+
+    const fastClient = new SkillNetClient({
+      apiUrl: "http://api.internal:8000",
+      apiKey: "sn_test_secret",
+      requestTimeoutMs: 5,
+    });
+
+    await expect(fastClient.listSkills()).rejects.toThrow();
+  });
+});

--- a/packages/skillnet-mcp/tests/testHarness.ts
+++ b/packages/skillnet-mcp/tests/testHarness.ts
@@ -1,0 +1,29 @@
+/** Minimal fake `McpServer` that just records what `registerTool` was called with. */
+export interface RegisteredTool {
+  name: string;
+  config: {
+    title?: string;
+    description?: string;
+    inputSchema?: unknown;
+    annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean };
+  };
+  handler: (args: any) => Promise<any>;
+}
+
+export class FakeMcpServer {
+  readonly tools = new Map<string, RegisteredTool>();
+
+  registerTool(
+    name: string,
+    config: RegisteredTool["config"],
+    handler: RegisteredTool["handler"]
+  ): void {
+    this.tools.set(name, { name, config, handler });
+  }
+
+  get(name: string): RegisteredTool {
+    const tool = this.tools.get(name);
+    if (!tool) throw new Error(`tool not registered: ${name}`);
+    return tool;
+  }
+}

--- a/packages/skillnet-mcp/tests/tools.test.ts
+++ b/packages/skillnet-mcp/tests/tools.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi } from "vitest";
+import { FakeMcpServer } from "./testHarness.js";
+import { registerListSkills } from "../src/tools/listSkills.js";
+import { registerWhoKnows } from "../src/tools/whoKnows.js";
+import { registerGetGap } from "../src/tools/getGap.js";
+import { registerGetUserSkills } from "../src/tools/getUserSkills.js";
+import { registerCreateCourse } from "../src/tools/createCourse.js";
+import { SkillNetApiError } from "../src/errors.js";
+import type { SkillNetClient } from "../src/skillnetClient.js";
+
+function fakeClient(overrides: Partial<SkillNetClient> = {}): SkillNetClient {
+  return overrides as SkillNetClient;
+}
+
+describe("list_skills", () => {
+  it("is read-only and reports totals on success", async () => {
+    const server = new FakeMcpServer();
+    const client = fakeClient({
+      listSkills: vi.fn().mockResolvedValue([
+        { id: "1", name: "Ventas", skills: [{ id: "a", name: "devoluciones" }] },
+      ]),
+    });
+    registerListSkills(server as any, client);
+
+    const tool = server.get("list_skills");
+    expect(tool.config.annotations?.readOnlyHint).toBe(true);
+
+    const result = await tool.handler({});
+    expect(result.isError).toBeUndefined();
+    expect(result.structuredContent.total_skills).toBe(1);
+    expect(result.content[0].text).toContain("devoluciones");
+  });
+
+  it("surfaces API errors without throwing out of the tool", async () => {
+    const server = new FakeMcpServer();
+    const client = fakeClient({
+      listSkills: vi.fn().mockRejectedValue(new SkillNetApiError("boom", 500, {})),
+    });
+    registerListSkills(server as any, client);
+
+    const result = await server.get("list_skills").handler({});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("boom");
+  });
+});
+
+describe("who_knows", () => {
+  it("readOnlyHint is set and results are summarized", async () => {
+    const server = new FakeMcpServer();
+    const client = fakeClient({
+      whoKnows: vi.fn().mockResolvedValue({
+        skill: "python",
+        employees: [{ user_id: "u1", full_name: "Juan Garcia", level: "high", source: "manual" }],
+      }),
+    });
+    registerWhoKnows(server as any, client);
+
+    const tool = server.get("who_knows");
+    expect(tool.config.annotations?.readOnlyHint).toBe(true);
+    const result = await tool.handler({ skill: "python" });
+    expect(result.content[0].text).toContain("Juan Garcia");
+    expect(result.structuredContent.employees).toHaveLength(1);
+  });
+
+  it("handles zero results gracefully", async () => {
+    const server = new FakeMcpServer();
+    const client = fakeClient({
+      whoKnows: vi.fn().mockResolvedValue({ skill: "rust", employees: [] }),
+    });
+    registerWhoKnows(server as any, client);
+
+    const result = await server.get("who_knows").handler({ skill: "rust" });
+    expect(result.content[0].text).toContain("No one");
+  });
+
+  it("propagates errors as tool errors, not exceptions", async () => {
+    const server = new FakeMcpServer();
+    const client = fakeClient({
+      whoKnows: vi.fn().mockRejectedValue(new Error("network down")),
+    });
+    registerWhoKnows(server as any, client);
+
+    const result = await server.get("who_knows").handler({ skill: "python" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("network down");
+  });
+});
+
+describe("get_gap", () => {
+  it("is read-only and lists gap severities", async () => {
+    const server = new FakeMcpServer();
+    const client = fakeClient({
+      getGap: vi.fn().mockResolvedValue({
+        gaps: [
+          {
+            skill: { id: "s1", name: "python" },
+            total_users: 12,
+            users_at_level: 2,
+            coverage_ratio: 0.17,
+            gap_severity: "critical",
+          },
+        ],
+      }),
+    });
+    registerGetGap(server as any, client);
+
+    const tool = server.get("get_gap");
+    expect(tool.config.annotations?.readOnlyHint).toBe(true);
+    const result = await tool.handler({});
+    expect(result.content[0].text).toContain("critical");
+  });
+
+  it("reports an error result on failure", async () => {
+    const server = new FakeMcpServer();
+    const client = fakeClient({ getGap: vi.fn().mockRejectedValue(new Error("timeout")) });
+    registerGetGap(server as any, client);
+
+    const result = await server.get("get_gap").handler({});
+    expect(result.isError).toBe(true);
+  });
+});
+
+describe("get_user_skills", () => {
+  it("is read-only and summarizes levels", async () => {
+    const server = new FakeMcpServer();
+    const client = fakeClient({
+      getUserSkills: vi.fn().mockResolvedValue([
+        { skill_id: "s1", skill_name: "devoluciones", level: "high", source: "checkpoint" },
+        { skill_id: "s2", skill_name: "html_css", level: "medium", source: "manual" },
+      ]),
+    });
+    registerGetUserSkills(server as any, client);
+
+    const tool = server.get("get_user_skills");
+    expect(tool.config.annotations?.readOnlyHint).toBe(true);
+    const result = await tool.handler({ user_id: "u1" });
+    expect(result.structuredContent.summary).toEqual({ low: 0, medium: 1, high: 1, total: 2 });
+  });
+
+  it("reports an error result on failure", async () => {
+    const server = new FakeMcpServer();
+    const client = fakeClient({
+      getUserSkills: vi.fn().mockRejectedValue(new SkillNetApiError("not found", 404, {})),
+    });
+    registerGetUserSkills(server as any, client);
+
+    const result = await server.get("get_user_skills").handler({ user_id: "missing" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("not found");
+  });
+});
+
+describe("create_course", () => {
+  it("is not read-only and not marked destructive", async () => {
+    const server = new FakeMcpServer();
+    const client = fakeClient({
+      createCourse: vi.fn().mockResolvedValue({
+        course_id: "c1",
+        title: "Onboarding",
+        schema_status: "validated",
+        node_count: 5,
+        packs_ready: 5,
+        packs_all_ready: true,
+        packs_summary: "5/5 nodes ready",
+        validated: true,
+        enrolled_user_id: null,
+        artifacts: [],
+        warnings: [],
+      }),
+    });
+    registerCreateCourse(server as any, client);
+
+    const tool = server.get("create_course");
+    expect(tool.config.annotations?.readOnlyHint).toBe(false);
+    expect(tool.config.annotations?.destructiveHint).toBe(false);
+  });
+
+  it("surfaces partial success and warnings honestly instead of a flat success", async () => {
+    const server = new FakeMcpServer();
+    const client = fakeClient({
+      createCourse: vi.fn().mockResolvedValue({
+        course_id: "c1",
+        title: "Higiene",
+        schema_status: "validated",
+        node_count: 8,
+        packs_ready: 6,
+        packs_all_ready: false,
+        packs_summary: "6/8 nodes ready",
+        validated: true,
+        enrolled_user_id: null,
+        artifacts: [],
+        warnings: ["only 6/8 knowledge packs reached ready within the timeout"],
+      }),
+    });
+    registerCreateCourse(server as any, client);
+
+    const result = await server.get("create_course").handler({ title: "Higiene" });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("not all ready yet");
+    expect(result.content[0].text).toContain("Warnings:");
+    expect(result.content[0].text).toContain("only 6/8 knowledge packs");
+    expect(result.structuredContent.warnings).toHaveLength(1);
+  });
+
+  it("reports create_course failures as tool errors", async () => {
+    const server = new FakeMcpServer();
+    const client = fakeClient({
+      createCourse: vi.fn().mockRejectedValue(new SkillNetApiError("courses:write required", 403, {})),
+    });
+    registerCreateCourse(server as any, client);
+
+    const result = await server.get("create_course").handler({ title: "X" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("courses:write");
+  });
+});

--- a/packages/skillnet-mcp/tsconfig.json
+++ b/packages/skillnet-mcp/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/skillnet-mcp/vitest.config.ts
+++ b/packages/skillnet-mcp/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Implementado

- Nuevo paquete `packages/skillnet-mcp/` (TypeScript, `@modelcontextprotocol/sdk`): servidor MCP remoto sobre **Streamable HTTP** (sin transporte SSE), cliente fino de `/ext/v1` — nunca toca PostgreSQL ni duplica logica de negocio.
- Tools expuestas al modelo: `list_skills`, `who_knows`, `get_gap`, `get_user_skills` (todas `readOnlyHint: true`) y `create_course` (envuelve `POST /ext/v1/courses/full`, `readOnlyHint: false`). `verify_skill` existe en la API pero **no** se expone como tool en este MVP, tal como pide la seccion 8.8.4 del diseno.
- `create_course` reporta con honestidad los exitos parciales: si `packs_all_ready` es `false` o hay `warnings`, aparecen en el texto y en `structuredContent`, nunca se aplanan a un exito simple.
- Autenticacion: API key de SkillNet como Bearer token, resuelta por request (`Authorization` o `X-Api-Key`) con fallback opcional a `SKILLNET_API_KEY` del entorno para despliegues de un solo tenant.
- Mensajes de error saneados (`src/errors.ts`): nunca se filtra la API key ni cabeceras de autorizacion, incluso en fallos de red o timeout.
- Endurecimiento de `/ext/v1` (`apps/skillnet-api/src/routes/ext/auth.py`), pendiente segun 8.8.2 del diseno:
  - se anade la columna `api_keys.expires_at` (migracion `0020`, nullable, aditiva) que faltaba en el modelo aunque el diseno de datos (8.1.1) ya la documentaba;
  - `_get_api_key` ahora rechaza una key expirada, no solo `is_active`;
  - nueva `require_scope(scope)` y dependencias `RequireSkillsRead` / `RequireSkillsWrite` / `RequireUsersRead` / `RequireCoursesWrite`, cableadas en `skills.py` y `courses.py` segun la tabla de scopes de 8.1.1 (`skills:read` para lecturas, `skills:write` para verificar, `users:read` para el perfil de usuario, `courses:write` para crear curso).
- Docker Compose: nuevo servicio `mcp` (perfil `mcp`, solo `127.0.0.1`) + `packages/skillnet-mcp/Dockerfile`, siguiendo el mismo patron que el servicio `a2a` existente.
- `packages/skillnet-mcp/.env.example` (sin secretos reales) y `README.md` con guia de conexion reproducible (cliente TS, `mcp-remote` para stdio).

## Pruebas

- `apps/skillnet-api`:
  - `uv run pytest tests/test_ext_auth.py -q` → 11 passed (scopes, expiracion, key A2A con los 4 scopes documentados, cabecera de auth invalida).
  - `uv run ruff check src/routes/ext src/models/api_key.py tests/test_ext_auth.py alembic/versions/0020_api_key_expires_at.py` → all checks passed.
  - `uv run pytest -m "not integration"` → 3498 passed, 1 fallo preexistente y no relacionado (`test_didact_snapshot_is_pinned_and_hashes_match`, snapshot de un vendor de terceros, no toca `api_keys` ni `/ext/v1`).
- `packages/skillnet-mcp`:
  - `npm run typecheck` (`tsc --noEmit`) → sin errores.
  - `npm run build` (`tsc`) → sin errores.
  - `npm test` (vitest, 4 archivos) → 30 passed. Cubre cada tool (camino feliz + error), el cliente HTTP (incluye timeout/abort y que el error nunca incluye la API key), resolucion de credencial por request vs. fallback de entorno, y carga de configuracion.
  - Smoke manual: `node dist/index.js` levantado en local, `initialize` por HTTP contra `/mcp` responde `200` con el `serverInfo` esperado.

## Limites y trabajo futuro

- Sin OAuth 2.1 / Dynamic Client Registration (paso 3 del roadmap en 8.8.8) — la autenticacion sigue siendo API key, como en el A2A existente.
- Sin MCP Apps / interfaz grafica (`ui://`, `_meta.ui.visibility`) — `verify_skill` sigue sin exponerse en absoluto, ni como tool de modelo ni como tool de app.
- Sin listado en ningun directorio de conectores.
- El servidor es *stateless* por request (cada llamada HTTP crea su propio `McpServer` + transporte ligado a la API key resuelta); no hay sesiones persistentes ni cache entre llamadas.
- No se tocaron `apps/skillnet-web`, la landing ni ningun fichero fuera del alcance indicado.